### PR TITLE
Add entropy aux lib

### DIFF
--- a/frontends/aux/esdm_aux_client.h
+++ b/frontends/aux/esdm_aux_client.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2024, Stephan Mueller <smueller@chronox.de>
+ *
+ * License: see LICENSE file in root directory
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ALL OF
+ * WHICH ARE HEREBY DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF NOT ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#ifndef ESDM_AUX_CLIENT_H
+#define ESDM_AUX_CLIENT_H
+
+#include <semaphore.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initialize the semaphore to be notified about inserting entropy
+ */
+int esdm_aux_init_wait_for_need_entropy(void);
+
+/**
+ * @brief Detach from the semaphore waiting to insert entropy
+ */
+void esdm_aux_fini_wait_for_need_entropy(void);
+
+/**
+ * @brief Timed wait for semaphore firing when ESDM server requires entropy
+ *
+ * When the ESDM server requires entropy, a semaphore is set to notify anybody
+ * who is interested that entropy shall be injected into the ESDM.
+ *
+ * A client that can deliver entropy shall sleep on the semaphore and then
+ * insert entropy when this call returns successfully. This API shall be
+ * invoked in a recursive loop so that the client injects entropy whenever
+ * the ESDM server wants it.
+ *
+ * This function allows the caller to specify a timeout when this function shall
+ * return even though the semaphore did not fire.
+ *
+ * The API is a wrapper around sem_clockwait([1]) including the purpose of the
+ * @param ts as well as the return code and the errno.
+ *
+ * @param [in] ts [1]
+ *
+ * @return See [1]
+ * 
+ * [1] https://www.gnu.org/software/libc/manual/html_node/Waiting-with-Explicit-Clocks.html
+ */
+int esdm_aux_timedwait_for_need_entropy(struct timespec *ts);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ESDM_AUX_CLIENT_H */

--- a/frontends/aux/esdm_aux_need_entropy.c
+++ b/frontends/aux/esdm_aux_need_entropy.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2024, Stephan Mueller <smueller@chronox.de>
+ *
+ * License: see LICENSE file in root directory
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ALL OF
+ * WHICH ARE HEREBY DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF NOT ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <semaphore.h>
+#include <string.h>
+#include <time.h>
+
+#include "esdm_aux_client.h"
+#include "esdm_logger.h"
+#include "esdm_rpc_service.h"
+#include "visibility.h"
+
+static sem_t *esdm_semid_need_entropy_level = SEM_FAILED;
+
+static int esdm_cuse_shm_status_down(struct timespec *ts)
+{
+	if (esdm_semid_need_entropy_level == SEM_FAILED) {
+		esdm_logger(LOGGER_ERR, LOGGER_C_ANY,
+			    "Cannot use semaphore\n");
+		errno = EINVAL;
+		return -1;
+	}
+
+	/* sem_timedwait uses CLOCK_REALTIME, which is subject to 
+	   clock adjustments, use sem_clockwait instead here */
+	return sem_clockwait(
+		esdm_semid_need_entropy_level,
+		CLOCK_MONOTONIC,
+		ts
+	);
+}
+
+static void esdm_cuse_shm_status_close_sem(void)
+{
+	if (esdm_semid_need_entropy_level != SEM_FAILED) {
+		sem_t *tmp = esdm_semid_need_entropy_level;
+
+		esdm_semid_need_entropy_level = SEM_FAILED;
+		sem_close(tmp);
+	}
+}
+
+static int esdm_cuse_shm_status_create_sem(void)
+{
+	int errsv;
+
+	// TODO: replace with ESDM_SEM_NEED_ENTROPY_LEVEL again when available
+	esdm_semid_need_entropy_level = sem_open(ESDM_SEM_RANDOM_NAME,
+						 O_CREAT | O_EXCL, 0644, 0);
+	if (esdm_semid_need_entropy_level == SEM_FAILED) {
+		if (errno == EEXIST) {
+			esdm_semid_need_entropy_level =
+				sem_open(ESDM_SEM_RANDOM_NAME, O_CREAT,
+					 0644, 0);
+			if (esdm_semid_need_entropy_level == SEM_FAILED)
+				goto err;
+		} else {
+			goto err;
+		}
+	}
+
+	esdm_logger(LOGGER_DEBUG, LOGGER_C_ANY,
+		    "ESDM change indicator semaphore initialized\n");
+
+	return 0;
+
+err:
+	errsv = errno;
+	esdm_logger(LOGGER_ERR, LOGGER_C_ANY,
+		    "ESDM change indicator semaphore creation failed: %s\n",
+		    strerror(errsv));
+	return -errsv;
+}
+
+DSO_PUBLIC
+int esdm_aux_init_wait_for_need_entropy(void)
+{
+	return esdm_cuse_shm_status_create_sem();
+}
+
+DSO_PUBLIC
+void esdm_aux_fini_wait_for_need_entropy(void)
+{
+	esdm_cuse_shm_status_close_sem();
+}
+
+DSO_PUBLIC
+int esdm_aux_timedwait_for_need_entropy(struct timespec *ts)
+{
+	return esdm_cuse_shm_status_down(ts);
+}

--- a/frontends/aux/meson.build
+++ b/frontends/aux/meson.build
@@ -1,0 +1,21 @@
+esdm_aux_src = [
+	'esdm_aux_need_entropy.c'
+]
+
+esdm_aux_lib = library(
+		'esdm-aux',
+		[
+		  esdm_aux_src
+		],
+		version: meson.project_version(),
+		soversion:version_array[0],
+		include_directories: include_dirs_client,
+		dependencies: [ dependencies_client ],
+		link_with: esdm_rpc_client_lib,
+		install: true
+		)
+pkgconfig.generate(esdm_aux_lib)
+
+include_user_files += files([
+	'esdm_aux_client.h'
+])

--- a/meson.build
+++ b/meson.build
@@ -149,6 +149,10 @@ if get_option('linux-getrandom').enabled()
 	subdirs += [ 'frontends/getrandom' ]
 endif
 
+if get_option('linux-aux').enabled()
+	subdirs += [ 'frontends/aux' ]
+endif
+
 if get_option('botan-rng').enabled()
 	add_languages('cpp', required: true)
 	botan_dep = dependency('botan-3', required: true)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -373,6 +373,9 @@ Using CUSE, the device files are provided.
 option('linux-getrandom', type: 'feature', value: 'enabled',
        description: 'Enable the Linux getrandom system call support.')
 
+option('linux-aux', type: 'feature', value: 'enabled',
+       description: 'Enable the Linux helper library for entropy status notifications.')
+
 option('botan-rng', type: 'feature', value: 'disabled',
        description: '''Enable the Botan >= 3 RNG support.
 


### PR DESCRIPTION
This PR adds a small helper library, which can be used with esdm-server in a standalone fashion. ESDM aux lib can monitor the entropy level of ESDM with a timeout.

The PR contains your patches with a small change to use sem_clockwait instead of sem_timedwait.