### PR TITLE
botan/openssl: fix dependency checks and small cleanup

### DIFF
--- a/esdm/meson.build
+++ b/esdm/meson.build
@@ -64,7 +64,6 @@ if get_option('crypto_backend') == 'builtin'
 		esdm_src += files([ 'esdm_builtin_sha512.c' ])
 	endif
 elif get_option('crypto_backend') == 'botan'
-	add_languages('cpp')
 	esdm_src += files([ 'esdm_botan.cpp' ])
 	dependencies_esdm_lib += [ dependency('botan', version: '>=3.0', required: true) ]
 elif get_option('crypto_backend') == 'gnutls'

--- a/meson.build
+++ b/meson.build
@@ -54,7 +54,7 @@ endif
 if cc.has_argument('-ffat-lto-objects')
 	add_global_arguments([ '-ffat-lto-objects' ],
 			     language: 'c')
-	if get_option('botan-rng').enabled()
+	if get_option('crypto_backend') == 'botan' or get_option('botan-rng').enabled()
 		add_global_arguments([ '-ffat-lto-objects' ],
 				language: 'cpp')
 	endif
@@ -166,15 +166,21 @@ if get_option('linux-getrandom').enabled()
 	subdirs += [ 'frontends/getrandom' ]
 endif
 
-if get_option('botan-rng').enabled()
+if get_option('crypto_backend') == 'botan' or get_option('botan-rng').enabled()
 	add_languages('cpp', required: true)
 	botan_dep = dependency('botan-3', required: true)
+endif
+
+if get_option('crypto_backend') == 'openssl' or get_option('openssl-rand-provider').enabled()
+	openssl_dep = dependency('openssl', required: true, version : '>=3.0')
+endif
+
+if get_option('botan-rng').enabled()
 	subdirs += [ 'frontends/botan-rng' ]
 	include_dirs_botan_rng = [ include_directories('frontends/botan-rng') ]
 endif
 
 if get_option('openssl-rand-provider').enabled()
-	openssl_dep = dependency('openssl', required: true, version : '>=3.0')
 	subdirs += [ 'frontends/openssl-provider' ]
 endif
 


### PR DESCRIPTION
Hi Stephan,

in my last PR I oversaw, that I always built with the OpenSSL + Botan Provider/RNG. This PR decouples them correctly.

BR
Markus