### PR TITLE
NTG.1 updates for AIS20/31 version 3.0

### DIFF
--- a/README.usage.md
+++ b/README.usage.md
@@ -84,10 +84,10 @@ the ESDM server operates compliant to SP800-90C right away when using the
 interfaces that are documented to block until sufficient initial entropy
 is present.
 
-## AIS 20/31 (2022) Compliance
+## AIS 20/31 (2024) Compliance
 
 When enabling the compile time option of `ais2031`, the ESDM server
-operates NTG.1 compliant to AIS 20/31 (2022 draft version) right away when using
+operates NTG.1 compliant to AIS 20/31 (2024, version 3.0) right away when using
 the interfaces that are documented to block until sufficient initial entropy
 is present.
 

--- a/esdm/esdm.h
+++ b/esdm/esdm.h
@@ -378,11 +378,11 @@ int esdm_ntg1_compliant(void);
 
 /**
  * @brief Indicator whether ESDM operates NTG.1 compliant according to
- * AIS 20/31 from 2022
+ * AIS 20/31 from 2024
  *
  * @return 1 if NTG.1 compliant, 0 if not NTG.1 compliant
  */
-int esdm_ntg1_2022_compliant(void);
+int esdm_ntg1_2024_compliant(void);
 
 /**
  * @brief Indicator whether at least one DRNG is fully seeded

--- a/esdm/esdm_definitions.h
+++ b/esdm/esdm_definitions.h
@@ -80,7 +80,7 @@
 #define ESDM_INIT_ENTROPY_BITS 32
 
 /* AIS20/31: NTG.1.4 minimum entropy rate for one entropy source*/
-#define ESDM_AIS2031_NPTRNG_MIN_ENTROPY 220
+#define ESDM_AIS2031_NPTRNG_MIN_ENTROPY 240
 
 /*
  * Wakeup value

--- a/esdm/esdm_drng_mgr.c
+++ b/esdm/esdm_drng_mgr.c
@@ -312,7 +312,7 @@ int esdm_ntg1_compliant(void)
 }
 
 DSO_PUBLIC
-int esdm_ntg1_2022_compliant(void)
+int esdm_ntg1_2024_compliant(void)
 {
 	return
 #ifdef ESDM_AIS2031_NTG1_SEEDING_STRATEGY
@@ -486,7 +486,7 @@ static uint32_t esdm_drng_seed_es_nolock(struct esdm_drng *drng, bool init_ops,
 	 * producing data while this is ongoing.
 	 */
 	} while (forced && !drng->fully_seeded &&
-		 num_es_delivered >= (esdm_ntg1_2022_compliant() ? 2 : 1));
+		 num_es_delivered >= (esdm_ntg1_2024_compliant() ? 2 : 1));
 
 	memset_secure(&seedbuf, 0, sizeof(seedbuf));
 

--- a/esdm/esdm_es_mgr.c
+++ b/esdm/esdm_es_mgr.c
@@ -435,8 +435,8 @@ static uint32_t esdm_avail_entropy_thresh(void)
 bool esdm_fully_seeded(bool fully_seeded, uint32_t collected_entropy,
 		       struct entropy_buf *eb)
 {
-	/* AIS20/31 NTG.1: two entropy sources with each delivering 220 bits */
-	if (esdm_ntg1_2022_compliant()) {
+	/* AIS20/31 NTG.1: two entropy sources with each delivering 240 bits */
+	if (esdm_ntg1_2024_compliant()) {
 		uint32_t i, result = 0,
 			    ent_thresh = esdm_avail_entropy_thresh();
 
@@ -552,8 +552,8 @@ void esdm_set_write_wakeup_bits(uint32_t val)
 
 static uint32_t esdm_init_entropy_level(bool fully_seeded)
 {
-	return esdm_ntg1_2022_compliant() ?
-		       /* Approximation so that two ES should deliver 220 bits each */
+	return esdm_ntg1_2024_compliant() ?
+		       /* Approximation so that two ES should deliver 240 bits each */
 		       (2 * ESDM_AIS2031_NPTRNG_MIN_ENTROPY) :
 		       /* Apply SP800-90C oversampling if applicable */
 		       esdm_get_seed_entropy_osr(fully_seeded);

--- a/esdm/esdm_info.c
+++ b/esdm/esdm_info.c
@@ -80,7 +80,7 @@ void esdm_status(char *buf, size_t buflen)
 		 esdm_nodes, esdm_config_fips_enabled() ? "FIPS 140 " : "",
 		 esdm_sp80090c_compliant() ? "SP800-90C " : "",
 		 esdm_ntg1_compliant() ? "NTG.1(2011) " : "",
-		 esdm_ntg1_2022_compliant() ? "NTG.1(2022)" : "",
+		 esdm_ntg1_2024_compliant() ? "NTG.1(2024)" : "",
 		 esdm_state_min_seeded() ? "true" : "false",
 		 esdm_state_fully_seeded() ? "true" : "false",
 		 esdm_avail_entropy());

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -274,18 +274,18 @@ The following oversampling is applied:
 
 # Option for: ESDM_AIS2031_NTG1_SEEDING_STRATEGY
 option('ais2031', type: 'boolean', value: 'false',
-       description:'''German AIS 20/31 (2022) compliance.
+       description:'''German AIS 20/31 3.0 (2024) compliance.
 
 When enabling this option, two entropy sources must
-deliver 220 bits of entropy each to consider a DRNG
+deliver 240 bits of entropy each to consider a DRNG
 as fully seeded. Any two entropy sources can be used
 to fulfill this requirement. If specific entropy sources
 shall not be capable of contributing to this seeding
 strategy, the respective entropy source must be configured
-to provide less than 220 bits of entropy.
+to provide less than 240 bits of entropy.
 
 The strategy is consistent with the requirements for
-NTG.1 compliance in German AIS 20/31 draft from 2022.
+NTG.1 compliance in German AIS 20/31 3.0 from 2024.
 
 Compliance with German AIS 20/31 from 2011 is always
 present when using /dev/random with the flag O_SYNC or


### PR DESCRIPTION
This is a first patch for AIS 20/31 3.0. DRG.4 adaptations need another (larger one), as we have to take generated bits and not requests into account (probably).