### PR TITLE
Add syslog logging support

### DIFF
--- a/common/esdm_logger.c
+++ b/common/esdm_logger.c
@@ -47,7 +47,7 @@ struct esdm_logger_class_map {
 static FILE *esdm_logger_stream = NULL;
 static bool use_syslog = false;
 
-void log_syslog(int severity, const char *format, ...);
+static void log_syslog(int severity, const char *format, ...);
 
 static const struct esdm_logger_class_map esdm_logger_class_mapping[] = {
 	{ LOGGER_C_ANY, NULL },
@@ -134,7 +134,7 @@ static int esdm_logger_class(const enum esdm_logger_class class, char *s,
 	return 0;
 }
 
-void log_syslog(int severity, const char *format, ...)
+static void log_syslog(int severity, const char *format, ...)
 {
 	va_list args;
 	int log_prio = LOG_NOTICE;

--- a/common/esdm_logger.c
+++ b/common/esdm_logger.c
@@ -373,6 +373,7 @@ ESDM_DEFINE_CONSTRUCTOR(esdm_logger_constructor);
 static void esdm_logger_constructor(void)
 {
 	esdm_logger_stream = stderr;
+	atexit(esdm_logger_destructor);
 }
 
 FILE *esdm_logger_log_stream(void)
@@ -395,7 +396,6 @@ int esdm_logger_set_file(const char *pathname)
 			    "Reject to set new log file\n");
 		return -EFAULT;
 	}
-	atexit(esdm_logger_destructor);
 
 	return 0;
 }

--- a/common/esdm_logger.c
+++ b/common/esdm_logger.c
@@ -454,8 +454,8 @@ void esdm_logger_inc_verbosity(void)
 }
 
 DSO_PUBLIC
-void esdm_logger_enable_syslog(void)
+void esdm_logger_enable_syslog(const char *daemon_name)
 {
 	use_syslog = true;
-	openlog("ESDM", LOG_NDELAY, LOG_DAEMON);
+	openlog(daemon_name ? daemon_name : "ESDM", LOG_NDELAY, LOG_DAEMON);
 }

--- a/common/esdm_logger.h
+++ b/common/esdm_logger.h
@@ -103,32 +103,6 @@ void _esdm_logger_binary(const enum esdm_logger_verbosity severity,
 #pragma GCC diagnostic pop
 
 /**
- * logger_binary - log binary string as hex
- * @param severity maximum severity level that causes the log entry to be logged
- * @param class logging class
- * @param bin binary string
- * @param binlen length of binary string
- * @param str string that is prepended to hex-converted binary string
- */
-#define esdm_logger_binary(severity, class_, bin, binlen, str)                 \
-	do {                                                                   \
-		_Pragma("GCC diagnostic push")                                 \
-			_Pragma("GCC diagnostic ignored \"-Wpedantic\"")       \
-				_esdm_logger_binary(severity, class_, bin,     \
-						    binlen, str, __FILE__,     \
-						    __FUNCTION__, __LINE__);   \
-		_Pragma("GCC diagnostic pop")                                  \
-	} while (0);
-
-/**
- * logger - log a percentage only if LOG_NONE is given
- * @param percentage Integer indicating a percentage value
- * @param fmt format string printed during first call
- */
-void esdm_logger_spinner(const unsigned int percentage, const char *fmt, ...)
-	__attribute__((format(printf, 2, 3)));
-
-/**
  * logger_set_verbosity - set verbosity level
  */
 void esdm_logger_set_verbosity(const enum esdm_logger_verbosity level);

--- a/common/esdm_logger.h
+++ b/common/esdm_logger.h
@@ -172,8 +172,9 @@ FILE *esdm_logger_log_stream(void);
 
 /**
  * enable logging to syslog instead of stderr
+ * @param [in] daemon_name may be null (then ESDM)
  */
-void esdm_logger_enable_syslog(void);
+void esdm_logger_enable_syslog(const char* daemon_name);
 
 #ifdef __cplusplus
 }

--- a/common/esdm_logger.h
+++ b/common/esdm_logger.h
@@ -157,7 +157,7 @@ void esdm_logger_inc_verbosity(void);
 /**
  * Log into the given file
  *
- * Note: The status logging will always log to stderr and will be always
+ * Note: The status logging will always log to stderr/syslog and will be always
  *	 active if a log file is set.
  *
  * @param [in] pathname Path name of log file
@@ -169,6 +169,11 @@ int esdm_logger_set_file(const char *pathname);
  * Retrieve the file stream to log to.
  */
 FILE *esdm_logger_log_stream(void);
+
+/**
+ * enable logging to syslog instead of stderr
+ */
+void esdm_logger_enable_syslog(void);
 
 #ifdef __cplusplus
 }

--- a/frontends/cuse/proc_files.c
+++ b/frontends/cuse/proc_files.c
@@ -570,6 +570,7 @@ static struct esdm_proc_options {
 	int show_help;
 	int relabel;
 	unsigned int verbosity;
+	int syslog;
 } esdm_proc_options;
 
 #define OPTION(t, p)                                                           \
@@ -579,7 +580,8 @@ static struct esdm_proc_options {
 static const struct fuse_opt esdm_proc_options_spec[] = {
 	OPTION("-v %u", verbosity),   OPTION("--verbosity=%u", verbosity),
 	OPTION("--relabel", relabel), OPTION("-h", show_help),
-	OPTION("--help", show_help),  FUSE_OPT_END
+	OPTION("--syslog", syslog), OPTION("--help", show_help),
+	FUSE_OPT_END
 };
 
 static void show_help(const char *progname)
@@ -588,6 +590,7 @@ static void show_help(const char *progname)
 	printf("File-system specific options:\n"
 	       "    --verbosity=<u>     Verbosity level\n"
 	       "    --relabel           Perform automatic SELinux relabeling"
+	       "    --syslog            Log via syslog"
 	       "\n");
 }
 
@@ -604,6 +607,10 @@ int main(int argc, char *argv[])
 	}
 
 	esdm_logger_set_verbosity(esdm_proc_options.verbosity);
+
+	if (esdm_proc_options.syslog) {
+		esdm_logger_enable_syslog("esdm-proc");
+	}
 
 	/*
 	 * When --help is specified, first print our own file-system

--- a/frontends/server/server_main.c
+++ b/frontends/server/server_main.c
@@ -26,7 +26,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "binhexbin.h"
 #include "esdm.h"
 #include "esdm_config.h"
 #include "esdm_rpc_server.h"

--- a/frontends/server/server_main.c
+++ b/frontends/server/server_main.c
@@ -145,7 +145,7 @@ static void parse_opts(int argc, char *argv[])
 
 			case 9:
 				/* syslog */
-				esdm_logger_enable_syslog();
+				esdm_logger_enable_syslog("esdm-server");
 				break;
 
 			default:
@@ -168,7 +168,7 @@ static void parse_opts(int argc, char *argv[])
 			foreground = 1;
 			break;
 		case 'S':
-			esdm_logger_enable_syslog();
+			esdm_logger_enable_syslog("esdm-server");
 			break;
 
 		case 'i':

--- a/frontends/server/server_main.c
+++ b/frontends/server/server_main.c
@@ -72,6 +72,8 @@ static void usage(void)
 	fprintf(stderr, "\t\t\t\tretries enabling it\n");
 	fprintf(stderr,
 		"\t   --jent_block_disable\tDisable Jitter RNG block collection\n");
+	fprintf(stderr,
+		"\t-S --syslog\tLog to syslog instead of stdout/stderr\n");
 	exit(1);
 }
 
@@ -92,8 +94,9 @@ static void parse_opts(int argc, char *argv[])
 						{ "force_schedes", 0, 0, 0 },
 						{ "jent_block_disable", 0, 0,
 						  0 },
+						{ "syslog", 0, 0, 0 },
 						{ 0, 0, 0, 0 } };
-		c = getopt_long(argc, argv, "hvp:u:fis", opts, &opt_index);
+		c = getopt_long(argc, argv, "hvp:u:fisS", opts, &opt_index);
 		if (-1 == c)
 			break;
 		switch (c) {
@@ -140,6 +143,11 @@ static void parse_opts(int argc, char *argv[])
 				esdm_config_es_jent_async_enabled_set(0);
 				break;
 
+			case 9:
+				/* syslog */
+				esdm_logger_enable_syslog();
+				break;
+
 			default:
 				usage();
 			}
@@ -158,6 +166,9 @@ static void parse_opts(int argc, char *argv[])
 			break;
 		case 'f':
 			foreground = 1;
+			break;
+		case 'S':
+			esdm_logger_enable_syslog();
 			break;
 
 		case 'i':


### PR DESCRIPTION
# Use case
esdm-server provides no useful logging, if used on a non-systemd Linux without log files.

# Questions/findings
* I found some currently unused logging functions (binary logging, percentage spinner), which are currently not using syslog. Shall they also be adapted or deleted?
* Can you live with the syslog parameter and checks or shall esdm_logger.c contain more splits on function level between syslog and stderr output?