### PR TITLE
Configurable kernel seeding interface

### DIFF
--- a/common/meson.build
+++ b/common/meson.build
@@ -132,4 +132,7 @@ conf_data.set('ESDM_RPCS_BUF_WRITE', not get_option('small_memory'))
 
 conf_data.set('ESDM_GETRANDOM_NUM_NODES', get_option('linux-getrandom-num-nodes'))
 
+conf_data.set('ESDM_LINUX_RESEED_INTERVAL_SEC', get_option('linux-reseed-interval'))
+conf_data.set('ESDM_LINUX_RESEED_ENTROPY_COUNT', get_option('linux-reseed-entropy-count'))
+
 configure_file(output: 'config.h', configuration : conf_data)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -393,6 +393,11 @@ if you want to use the OpenSSL as a provider for ESDM-internal crypto algorithms
 like hash algorithms.
 ''')
 
+option('linux-reseed-interval', type: 'integer', value: 120,
+       description: 'interval between forced Linux kernel RNG reseeds (in seconds)')
+option('linux-reseed-entropy-count', type: 'integer', value: 0, min: 0, max: 256,
+       description: 'amount of entropy to account on kernel reseed (without es_irq)')
+
 option('esdm-server', type: 'feature', value: 'enabled',
        description: 'Enable the ESDM server')
 

--- a/service-rpc/server/esdm_rpc_server_linux.c
+++ b/service-rpc/server/esdm_rpc_server_linux.c
@@ -134,8 +134,8 @@ static int esdm_rpcs_linux_feed_kernel(void __unused *unused)
 	struct rand_pool_info *rpi = (struct rand_pool_info *)rpi_buf;
 	struct esdm_status_st status;
 
-	/* Wake up every 2 minutes */
-	struct timespec ts = { .tv_sec = 120, .tv_nsec = 0 };
+	/* Wake up every 2 minutes by default */
+	struct timespec ts = { .tv_sec = ESDM_LINUX_RESEED_INTERVAL_SEC, .tv_nsec = 0 };
 	ssize_t ret;
 
 	thread_set_name(es_kernel_feeder, 0);
@@ -165,7 +165,7 @@ static int esdm_rpcs_linux_feed_kernel(void __unused *unused)
 			if (status.es_irq_enabled)
 				rpi->entropy_count = (int)((ret) << 3);
 			else
-				rpi->entropy_count = 0;
+				rpi->entropy_count = ESDM_LINUX_RESEED_ENTROPY_COUNT;
 			esdm_rpcs_linux_insert_entropy(rpi);
 		}
 

--- a/service-rpc/server/esdm_rpc_server_linux.c
+++ b/service-rpc/server/esdm_rpc_server_linux.c
@@ -160,9 +160,14 @@ static int esdm_rpcs_linux_feed_kernel(void __unused *unused)
 			 * claim it has entropy. Conversely, if the IRQ ES is
 			 * not enabled* it has its main entropy source and is
 			 * credited with entropy by the ESDM. This implies
-			 * we cannot inject data that we claim has entropy.
+			 * we cannot inject data that we claim has entropy
+			 * unless other entropy sources are accessible in
+			 * ESDM (e.g. a smartcard feeding the auxiliary pool).
+			 *
+			 * You can change ESDM_LINUX_RESEED_ENTROPY_COUNT
+			 * in these cases.
 			 */
-			if (status.es_irq_enabled)
+			if (status.es_irq_enabled && ESDM_LINUX_RESEED_ENTROPY_COUNT == 0)
 				rpi->entropy_count = (int)((ret) << 3);
 			else
 				rpi->entropy_count = ESDM_LINUX_RESEED_ENTROPY_COUNT;


### PR DESCRIPTION
When additional entropy sources (e.g. smartcards) are present and/or the kernel RNG is used to generate IVs for e.g. network or disk encryption, configurable kernel seeding intervals and entropy count is useful.