### PR TITLE
drng_mgr: optionally enforce bit limit of DRG.4 in AIS 20/31 3.0

### DIFF
--- a/common/helper.c
+++ b/common/helper.c
@@ -29,10 +29,10 @@
 
 uint32_t esdm_online_nodes(void)
 {
-	static uint32_t cpus = 0xFFFFFFFF;
+	static uint32_t cpus = UINT32_MAX;
 
 	/* We do not need more DRNGs than we have CPUs */
-	if (cpus == 0xFFFFFFFF) {
+	if (cpus == UINT32_MAX) {
 #ifdef _POSIX_SOURCE
 		long ncpus = sysconf(_SC_NPROCESSORS_ONLN);
 

--- a/common/meson.build
+++ b/common/meson.build
@@ -135,6 +135,7 @@ conf_data.set('ESDM_GETRANDOM_NUM_NODES', get_option('linux-getrandom-num-nodes'
 conf_data.set('ESDM_LINUX_RESEED_INTERVAL_SEC', get_option('linux-reseed-interval'))
 conf_data.set('ESDM_LINUX_RESEED_ENTROPY_COUNT', get_option('linux-reseed-entropy-count'))
 
+conf_data.set('ESDM_DRNG_RESEED_THRESH_BITS', get_option('drng_reseed_threshold_bits'))
 conf_data.set('ESDM_DRNG_MAX_RESEED_BITS', get_option('drng_max_reseed_bits'))
 
 configure_file(output: 'config.h', configuration : conf_data)

--- a/common/meson.build
+++ b/common/meson.build
@@ -135,4 +135,6 @@ conf_data.set('ESDM_GETRANDOM_NUM_NODES', get_option('linux-getrandom-num-nodes'
 conf_data.set('ESDM_LINUX_RESEED_INTERVAL_SEC', get_option('linux-reseed-interval'))
 conf_data.set('ESDM_LINUX_RESEED_ENTROPY_COUNT', get_option('linux-reseed-entropy-count'))
 
+conf_data.set('ESDM_DRNG_MAX_RESEED_BITS', get_option('drng_max_reseed_bits'))
+
 configure_file(output: 'config.h', configuration : conf_data)

--- a/esdm/esdm_config.c
+++ b/esdm/esdm_config.c
@@ -310,7 +310,7 @@ void esdm_config_drng_max_wo_reseed_set(uint32_t val)
 	esdm_config.esdm_drng_max_wo_reseed = val;
 }
 
-void esdm_config_drng_max_wo_reseed_bits_set(int32_t val)
+void esdm_config_drng_max_wo_reseed_bits_set(uint32_t val)
 {
 	esdm_config.esdm_drng_max_wo_reseed_bits = val;
 }

--- a/esdm/esdm_config.c
+++ b/esdm/esdm_config.c
@@ -40,6 +40,7 @@ struct esdm_config {
 	uint32_t esdm_es_hwrand_entropy_rate_bits;
 	uint32_t esdm_es_jent_kernel_entropy_rate_bits;
 	uint32_t esdm_drng_max_wo_reseed;
+	int32_t esdm_drng_max_wo_reseed_bits;
 	uint32_t esdm_max_nodes;
 	enum esdm_config_force_fips force_fips;
 
@@ -96,6 +97,11 @@ static struct esdm_config esdm_config = {
 	 * See documentation of ESDM_DRNG_MAX_WITHOUT_RESEED.
 	 */
 	.esdm_drng_max_wo_reseed = ESDM_DRNG_MAX_WITHOUT_RESEED,
+
+	/*
+	 * See documentation of ESDM_DRNG_MAX_RESEED_BITS.
+	 */
+	.esdm_drng_max_wo_reseed_bits = ESDM_DRNG_MAX_RESEED_BITS,
 
 	/*
 	 * Upper limit of DRNG nodes
@@ -283,6 +289,15 @@ uint32_t esdm_config_drng_max_wo_reseed(void)
 	return esdm_config.esdm_drng_max_wo_reseed;
 }
 
+
+DSO_PUBLIC
+int32_t esdm_config_drng_max_wo_reseed_bits(void)
+{
+	/* If DRNG operated without proper reseed for too long, block ESDM */
+	BUILD_BUG_ON(ESDM_DRNG_MAX_RESEED_BITS < ESDM_DRNG_RESEED_THRESH_BITS);
+	return esdm_config.esdm_drng_max_wo_reseed_bits;
+}
+
 DSO_PUBLIC
 uint32_t esdm_config_max_nodes(void)
 {
@@ -293,6 +308,11 @@ uint32_t esdm_config_max_nodes(void)
 void esdm_config_drng_max_wo_reseed_set(uint32_t val)
 {
 	esdm_config.esdm_drng_max_wo_reseed = val;
+}
+
+void esdm_config_drng_max_wo_reseed_bits_set(int32_t val)
+{
+	esdm_config.esdm_drng_max_wo_reseed_bits = val;
 }
 
 void esdm_config_max_nodes_set(uint32_t val)

--- a/esdm/esdm_config.c
+++ b/esdm/esdm_config.c
@@ -40,7 +40,7 @@ struct esdm_config {
 	uint32_t esdm_es_hwrand_entropy_rate_bits;
 	uint32_t esdm_es_jent_kernel_entropy_rate_bits;
 	uint32_t esdm_drng_max_wo_reseed;
-	int32_t esdm_drng_max_wo_reseed_bits;
+	uint32_t esdm_drng_max_wo_reseed_bits;
 	uint32_t esdm_max_nodes;
 	enum esdm_config_force_fips force_fips;
 
@@ -106,7 +106,7 @@ static struct esdm_config esdm_config = {
 	/*
 	 * Upper limit of DRNG nodes
 	 */
-	.esdm_max_nodes = 0xffffffff,
+	.esdm_max_nodes = UINT32_MAX,
 
 	/* Shall the FIPS mode be forcefully set/unset? */
 	.force_fips = esdm_config_force_fips_unset,
@@ -291,7 +291,7 @@ uint32_t esdm_config_drng_max_wo_reseed(void)
 
 
 DSO_PUBLIC
-int32_t esdm_config_drng_max_wo_reseed_bits(void)
+uint32_t esdm_config_drng_max_wo_reseed_bits(void)
 {
 	/* If DRNG operated without proper reseed for too long, block ESDM */
 	BUILD_BUG_ON(ESDM_DRNG_MAX_RESEED_BITS < ESDM_DRNG_RESEED_THRESH_BITS);

--- a/esdm/esdm_config.h
+++ b/esdm/esdm_config.h
@@ -200,7 +200,7 @@ uint32_t esdm_config_es_jent_kernel_entropy_rate(void);
 
 /**
  * @brief DRNG Manager configuration: get maximum value without successful
- *	  reseed
+ *	  reseed (number of requests)
  *
  * If the DRNG is reseeded but insufficient entropy is present, the DRNG
  * continues to operate. However, if the reseed with insufficient entropy
@@ -211,6 +211,21 @@ uint32_t esdm_config_es_jent_kernel_entropy_rate(void);
  *	   an full entropy.
  */
 uint32_t esdm_config_drng_max_wo_reseed(void);
+
+/**
+ * @brief DRNG Manager configuration: get maximum number of bits drawn before
+ *	  reseed
+ *
+ * Class DRG.4 in German AIS 20/31 version 3.0 enforces a limit of 2**17
+ * bits drawn at max from a DRNG instance before the next reseeding is enforced.
+ * If you encounter similar limits, this setting can be used to enforced them.
+ * Otherwise set to a sufficiently large value, such that the request count triggers
+ * first.
+ *
+ * @return Number of DRNG internal random numbers which are allowed to deliver
+ *	   after a full entropy reseed.
+ */
+int32_t esdm_config_drng_max_wo_reseed_bits(void);
 
 /**
  * @brief DRNG Manager configuration: get number of DRNG instances

--- a/esdm/esdm_config.h
+++ b/esdm/esdm_config.h
@@ -225,7 +225,7 @@ uint32_t esdm_config_drng_max_wo_reseed(void);
  * @return Number of DRNG internal random numbers which are allowed to deliver
  *	   after a full entropy reseed.
  */
-int32_t esdm_config_drng_max_wo_reseed_bits(void);
+uint32_t esdm_config_drng_max_wo_reseed_bits(void);
 
 /**
  * @brief DRNG Manager configuration: get number of DRNG instances

--- a/esdm/esdm_config_internal.h
+++ b/esdm/esdm_config_internal.h
@@ -28,6 +28,7 @@ int esdm_config_reinit(void);
 
 #ifdef ESDM_TESTMODE
 void esdm_config_drng_max_wo_reseed_set(uint32_t val);
+void esdm_config_drng_max_wo_reseed_bits_set(int32_t val);
 void esdm_config_max_nodes_set(uint32_t val);
 #endif
 

--- a/esdm/esdm_config_internal.h
+++ b/esdm/esdm_config_internal.h
@@ -28,7 +28,7 @@ int esdm_config_reinit(void);
 
 #ifdef ESDM_TESTMODE
 void esdm_config_drng_max_wo_reseed_set(uint32_t val);
-void esdm_config_drng_max_wo_reseed_bits_set(int32_t val);
+void esdm_config_drng_max_wo_reseed_bits_set(uint32_t val);
 void esdm_config_max_nodes_set(uint32_t val);
 #endif
 

--- a/esdm/esdm_drng_mgr.c
+++ b/esdm/esdm_drng_mgr.c
@@ -396,6 +396,7 @@ void esdm_drng_inject(struct esdm_drng *drng, const uint8_t *inbuf,
 		 */
 		if (fully_seeded) {
 			atomic_set(&drng->requests_since_fully_seeded, 0);
+			atomic_set(&drng->request_bits_since_fully_seeded, 0);
 		} else
 			atomic_add(&drng->requests_since_fully_seeded, gc);
 
@@ -494,8 +495,6 @@ static uint32_t esdm_drng_seed_es_nolock(struct esdm_drng *drng, bool init_ops,
 		 num_es_delivered >= (esdm_ntg1_2024_compliant() ? 2 : 1));
 
 	memset_secure(&seedbuf, 0, sizeof(seedbuf));
-
-	atomic_set(&drng->request_bits_since_fully_seeded, 0);
 
 	return collected_entropy;
 }
@@ -623,8 +622,9 @@ static bool esdm_drng_check_disable_threshold(struct esdm_drng *drng)
 {
 	bool request_limit_reached = atomic_read_u32(&drng->requests_since_fully_seeded) >=
 	    			     esdm_config_drng_max_wo_reseed();
-	bool bit_limit_reached = atomic_read_u32(&drng->request_bits_since_fully_seeded) >=
-				 esdm_config_drng_max_wo_reseed_bits();
+	bool bit_limit_reached = (esdm_config_drng_max_wo_reseed_bits() != UINT32_MAX) &&
+				 (atomic_read_u32(&drng->request_bits_since_fully_seeded) >=
+				 esdm_config_drng_max_wo_reseed_bits());
 
 	return request_limit_reached || bit_limit_reached;
 }
@@ -668,7 +668,9 @@ out:
 static bool esdm_drng_must_reseed(struct esdm_drng *drng)
 {
 	struct timespec check_time = drng->last_seeded;
-	bool request_bits_since_fully_seeded_reached = atomic_read_u32(&drng->request_bits_since_fully_seeded) >= ESDM_DRNG_RESEED_THRESH_BITS;
+	bool request_bits_since_fully_seeded_reached = (ESDM_DRNG_RESEED_THRESH_BITS != UINT32_MAX) &&
+						       (atomic_read_u32(&drng->request_bits_since_fully_seeded) >=
+						       ESDM_DRNG_RESEED_THRESH_BITS);
 
 	check_time.tv_sec += esdm_drng_reseed_max_time;
 	return (atomic_dec_and_test(&drng->requests) || drng->force_reseed || request_bits_since_fully_seeded_reached ||
@@ -775,8 +777,6 @@ static ssize_t esdm_drng_get(struct esdm_drng *drng, uint8_t *outbuf,
 
 			/* Do not produce more than DRNG security strength. */
 			todo = min_uint32(todo, esdm_security_strength() >> 3);
-
-			atomic_set(&drng->request_bits_since_fully_seeded, 0);
 		}
 
 		/* Now, generate random bits from the properly seeded DRNG. */

--- a/esdm/esdm_drng_mgr.c
+++ b/esdm/esdm_drng_mgr.c
@@ -622,9 +622,8 @@ static bool esdm_drng_check_disable_threshold(struct esdm_drng *drng)
 {
 	bool request_limit_reached = atomic_read_u32(&drng->requests_since_fully_seeded) >
 	    			     esdm_config_drng_max_wo_reseed();
-	bool bit_limit_reached = (esdm_config_drng_max_wo_reseed_bits() != UINT32_MAX) &&
-				 (atomic_read_u32(&drng->request_bits_since_fully_seeded) >
-				 (esdm_config_drng_max_wo_reseed_bits()));
+	bool bit_limit_reached = atomic_read_u32(&drng->request_bits_since_fully_seeded) >
+				 esdm_config_drng_max_wo_reseed_bits();
 
 	return request_limit_reached || bit_limit_reached;
 }
@@ -668,7 +667,7 @@ out:
 static bool esdm_drng_must_reseed(struct esdm_drng *drng)
 {
 	struct timespec check_time = drng->last_seeded;
-	bool request_bits_since_fully_seeded_reached = (ESDM_DRNG_RESEED_THRESH_BITS != UINT32_MAX) && (atomic_read_u32(&drng->request_bits_since_fully_seeded) >= ESDM_DRNG_RESEED_THRESH_BITS);
+	bool request_bits_since_fully_seeded_reached = atomic_read_u32(&drng->request_bits_since_fully_seeded) > ESDM_DRNG_RESEED_THRESH_BITS;
 
 	check_time.tv_sec += esdm_drng_reseed_max_time;
 	return (atomic_dec_and_test(&drng->requests) || drng->force_reseed || request_bits_since_fully_seeded_reached ||

--- a/esdm/esdm_drng_mgr.h
+++ b/esdm/esdm_drng_mgr.h
@@ -45,6 +45,8 @@ struct esdm_drng {
 	atomic_t requests_since_fully_seeded; /* Number DRNG requests since
 						 * last fully seeded
 						 */
+	atomic_t internal_bits; /* DRG.4.10 AIS 20/31 Version 3.0 */
+
 	struct timespec last_seeded; /* Last time it was seeded */
 	bool fully_seeded; /* Is DRNG fully seeded? */
 	bool force_reseed; /* Force a reseed */
@@ -57,7 +59,9 @@ struct esdm_drng {
 #define ESDM_DRNG_STATE_INIT(x, d, d_cb, h_cb)                                 \
 	.drng = d, .drng_cb = d_cb, .hash_cb = h_cb,                           \
 	.requests = ATOMIC_INIT(ESDM_DRNG_RESEED_THRESH),                      \
-	.requests_since_fully_seeded = ATOMIC_INIT(0), .last_seeded = {0},     \
+	.requests_since_fully_seeded = ATOMIC_INIT(0),                         \
+	.internal_bits = ATOMIC_INIT(0),                                       \
+	.last_seeded = {0},                                                    \
 	.fully_seeded = false, .force_reseed = true,                           \
 	.hash_lock = MUTEX_UNLOCKED
 

--- a/esdm/esdm_drng_mgr.h
+++ b/esdm/esdm_drng_mgr.h
@@ -45,7 +45,14 @@ struct esdm_drng {
 	atomic_t requests_since_fully_seeded; /* Number DRNG requests since
 						 * last fully seeded
 						 */
-	atomic_t internal_bits; /* DRG.4.10 AIS 20/31 Version 3.0 */
+	/* tracks number of bits this DRNG has output since beeing fully seeded for
+	 * the last time. This is used to implement AIS 20/31 Version 3.0, DRG.4.10.
+	 * This requirement states, that a DRG.4 should be reseeded after at max 2**17
+	 * bits were returned to consumers. This cannot be checked against the number of
+	 * requests without overestimating by a large margin (alway maximum request size)
+	 * and therefore reseeding way too often.
+	 */
+	atomic_t request_bits_since_fully_seeded;
 
 	struct timespec last_seeded; /* Last time it was seeded */
 	bool fully_seeded; /* Is DRNG fully seeded? */
@@ -60,7 +67,7 @@ struct esdm_drng {
 	.drng = d, .drng_cb = d_cb, .hash_cb = h_cb,                           \
 	.requests = ATOMIC_INIT(ESDM_DRNG_RESEED_THRESH),                      \
 	.requests_since_fully_seeded = ATOMIC_INIT(0),                         \
-	.internal_bits = ATOMIC_INIT(0),                                       \
+	.request_bits_since_fully_seeded = ATOMIC_INIT(0),                     \
 	.last_seeded = {0},                                                    \
 	.fully_seeded = false, .force_reseed = true,                           \
 	.hash_lock = MUTEX_UNLOCKED

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -311,18 +311,32 @@ shall be adjusted.
 The value must not be lower than 1.
 ''')
 
-option('drng_reseed_threshold_bits', type: 'integer', value: -1,
-       description: '''Set this to anything lower than 131072 (2**17) to enforce
-       DRG.4.10 of AIS 20/31 Version 3.0
-       
-       If you wan't to disable this strict check, simply set it -1.
+option('drng_reseed_threshold_bits', type: 'integer', value: 0xffffffff,
+       description: '''Besides request count based reseeding, this option can
+       be used to enable request size (Bit) based reseeding. Set this to
+       UINT32_MAX (0xffffffff) to disable it (default).
+
+       Request size based reseeding works in two stages.
+       After 'drng_reseed_threshold_bits' (this option) the DRNG code
+       tries to reseed the DRNG instance.
+
+       If this was unsucessful multiple times, the DRNG changes into
+       the unseeded state after 'drng_max_reseed_bits' bits.
+       Therefore 'drng_max_reseed_bits' always has to be larger than
+       'drng_reseed_threshold_bits'.
+
+       Set this setting to anything lower than 131072 (2**17) to enforce
+       DRG.4.10 of AIS 20/31 Version 3.0. E.g. 65536 (2**16) and
+       'drng_max_reseed_bits' to 131072 (2**17).
        ''')
 
-option('drng_max_reseed_bits', type: 'integer', value: -1,
-       description: '''Set this to 131072 (2**17) to enforce
-       DRG.4.10 of AIS 20/31 Version 3.0
-       
-       If you wan't to disable this strict check, simply set it -1.
+option('drng_max_reseed_bits', type: 'integer', value: 0xffffffff,
+       description: '''This sets the maximum number of output/request bits before
+       the DRNG instances become loose their fully seeded state without
+       successful reseeding.
+
+       UINT32_MAX (0xffffffff) disables this setting. For more details on this
+       setting see the description of 'drng_reseed_threshold_bits'.
        ''')
 
 ################################################################################

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -311,9 +311,19 @@ shall be adjusted.
 The value must not be lower than 1.
 ''')
 
-option('drng_max_reseed_bits', type: 'integer', value: 131072,
+option('drng_reseed_threshold_bits', type: 'integer', value: -1,
+       description: '''Set this to anything lower than 131072 (2**17) to enforce
+       DRG.4.10 of AIS 20/31 Version 3.0
+       
+       If you wan't to disable this strict check, simply set it -1.
+       ''')
+
+option('drng_max_reseed_bits', type: 'integer', value: -1,
        description: '''Set this to 131072 (2**17) to enforce
-       DRG.4.10 of AIS 20/31 Version 3.0''')
+       DRG.4.10 of AIS 20/31 Version 3.0
+       
+       If you wan't to disable this strict check, simply set it -1.
+       ''')
 
 ################################################################################
 # Cryptographic backends configuration

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -311,6 +311,10 @@ shall be adjusted.
 The value must not be lower than 1.
 ''')
 
+option('drng_max_reseed_bits', type: 'integer', value: 131072,
+       description: '''Set this to 131072 (2**17) to enforce
+       DRG.4.10 of AIS 20/31 Version 3.0''')
+
 ################################################################################
 # Cryptographic backends configuration
 ################################################################################

--- a/service-rpc/client/esdm_rpc_client.c
+++ b/service-rpc/client/esdm_rpc_client.c
@@ -604,7 +604,7 @@ out:
 /******************************************************************************
  * General service handlers
  ******************************************************************************/
-static uint32_t esdm_rpcc_max_nodes = 0xffffffff;
+static uint32_t esdm_rpcc_max_nodes = UINT32_MAX;
 
 DSO_PUBLIC
 int esdm_rpcc_set_max_online_nodes(uint32_t nodes)

--- a/tests/esdm/esdm_drng_mgr_max_wo_reseed_bits_test.c
+++ b/tests/esdm/esdm_drng_mgr_max_wo_reseed_bits_test.c
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2022 - 2024, Stephan Mueller <smueller@chronox.de>
+ *
+ * License: see LICENSE file in root directory
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ALL OF
+ * WHICH ARE HEREBY DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF NOT ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <limits.h>
+#include <sched.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include "config.h"
+#include "esdm.h"
+#include "esdm_config.h"
+#include "esdm_config_internal.h"
+#include "esdm_es_mgr.h"
+#include "esdm_logger.h"
+#include "ret_checkers.h"
+
+#ifdef ESDM_TESTMODE
+static int esdm_drng_mgr_max_wo_reseed_bits_test(bool success)
+{
+	uint8_t buf[256];
+	unsigned int i;
+	int ret;
+
+	esdm_logger_set_verbosity(LOGGER_DEBUG);
+
+	esdm_config_es_cpu_entropy_rate_set(ESDM_DRNG_SECURITY_STRENGTH_BITS);
+	esdm_config_es_jent_entropy_rate_set(ESDM_DRNG_SECURITY_STRENGTH_BITS);
+
+	CKINT(esdm_init());
+
+	esdm_get_random_bytes(buf, sizeof(buf));
+
+	/* Wait for fully seeded */
+	sleep(1);
+
+	if (!esdm_state_fully_seeded()) {
+		printf("ESDM is not fully seeded!\n");
+		goto err;
+	}
+
+	for (i = 0; i < 10; i++) {
+		if (esdm_get_random_bytes(buf, sizeof(buf)) != sizeof(buf)) {
+			printf("cannot obtain random data\n");
+			goto err;
+		}
+	}
+
+	esdm_drng_force_reseed();
+	esdm_config_drng_max_wo_reseed_bits_set(256);
+
+	esdm_config_es_cpu_entropy_rate_set(0);
+	esdm_config_es_jent_entropy_rate_set(0);
+	esdm_config_es_krng_entropy_rate_set(0);
+	esdm_config_es_hwrand_entropy_rate_set(0);
+	esdm_config_es_irq_entropy_rate_set(0);
+	esdm_config_es_sched_entropy_rate_set(0);
+	esdm_config_es_jent_kernel_entropy_rate_set(0);
+
+	if (!esdm_state_operational()) {
+		printf("failed to remain in operational mode\n");
+		goto err;
+	}
+
+	esdm_drng_force_reseed();
+	esdm_get_random_bytes(buf, sizeof(buf));
+	if (esdm_state_operational() != success) {
+		printf("failed to %soperational mode\n",
+		       success ? "remain in " : "enter non-");
+		goto err;
+	}
+
+out:
+	esdm_fini();
+	return ret;
+err:
+	ret = 1;
+	goto out;
+}
+#endif
+
+int main(int argc, char *argv[])
+{
+#ifdef ESDM_TESTMODE
+	cpu_set_t set;
+	unsigned long drng_instances;
+	int ret;
+
+	if (argc != 2) {
+		printf("Provide number of DRNG instances to be created\n");
+		return 1;
+	}
+
+	drng_instances = strtoul(argv[1], NULL, 10);
+	if (drng_instances == ULONG_MAX)
+		return errno;
+	if (drng_instances > UINT32_MAX)
+		return 1;
+
+	/*
+	 * Test idea: instantiate 1 DRNG and set the max without reseed
+	 * threshold to 2. Also set all entropy sources to deliver insufficient
+	 * entropy. Now, cause 2 reseeds and verify that the DRNG goes
+	 * into non-operational mode.
+	 */
+	esdm_config_max_nodes_set((uint32_t)drng_instances);
+	if (drng_instances > 1) {
+		CPU_ZERO(&set);
+		CPU_SET(1, &set);
+		if (sched_setaffinity(getpid(), sizeof(cpu_set_t), &set) ==
+		    -1) {
+			printf("Cannot pin process to CPU 1\n");
+			return 1;
+		}
+		if (sched_getcpu() < 1) {
+			printf("Cannot pin process to CPU 1\n");
+			return 1;
+		}
+	}
+	ret = esdm_drng_mgr_max_wo_reseed_bits_test(drng_instances > 1 ? true :
+						    false);
+
+	return ret;
+#else
+	(void)argc;
+	(void)argv;
+	return 77;
+#endif
+}

--- a/tests/esdm/meson.build
+++ b/tests/esdm/meson.build
@@ -47,6 +47,14 @@ if get_option('esdm-server').enabled()
 		dependencies: dependencies_server,
 	)
 
+	esdm_drng_mgr_max_wo_reseed_bits_test = executable(
+		'esdm_drng_mgr_max_wo_reseed_bits_test',
+		[ 'esdm_drng_mgr_max_wo_reseed_bits_test.c' ],
+		include_directories: include_dirs_server,
+		link_with: esdm_static_lib,
+		dependencies: dependencies_server,
+	)
+
 	esdm_drng_seed_entropy_test = executable(
 		'esdm_drng_seed_entropy_test',
 		[ 'esdm_drng_seed_entropy_test.c' ],
@@ -72,6 +80,13 @@ if get_option('esdm-server').enabled()
 		args : [ '1' ],
 		is_parallel: false)
 	test('ESDM DRNG manager max w/o reseed - 2 DRNG', esdm_drng_mgr_max_wo_reseed_test,
+		args : [ '2' ],
+		is_parallel: false)
+
+	test('ESDM DRNG manager max w/o reseed bits - 1 DRNG', esdm_drng_mgr_max_wo_reseed_bits_test,
+		args : [ '1' ],
+		is_parallel: false)
+	test('ESDM DRNG manager max w/o reseed bits - 2 DRNG', esdm_drng_mgr_max_wo_reseed_bits_test,
 		args : [ '2' ],
 		is_parallel: false)
 


### PR DESCRIPTION
AIS 20/31 has brought us new limits for DRG.4 reseeding with DRG.4.10. This PR adapts ESDM for (optional) configurable bit limits for reseeding.