### PR TITLE
allow for compile time configuration of RPC base path

### DIFF
--- a/common/meson.build
+++ b/common/meson.build
@@ -135,4 +135,6 @@ conf_data.set('ESDM_GETRANDOM_NUM_NODES', get_option('linux-getrandom-num-nodes'
 conf_data.set('ESDM_LINUX_RESEED_INTERVAL_SEC', get_option('linux-reseed-interval'))
 conf_data.set('ESDM_LINUX_RESEED_ENTROPY_COUNT', get_option('linux-reseed-entropy-count'))
 
+conf_data.set_quoted('ESDM_SERVER_RPC_BASE_PATH', get_option('esdm-server-rpc-path'))
+
 configure_file(output: 'config.h', configuration : conf_data)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -401,6 +401,13 @@ option('linux-reseed-entropy-count', type: 'integer', value: 0, min: 0, max: 256
 option('esdm-server', type: 'feature', value: 'enabled',
        description: 'Enable the ESDM server')
 
+option('esdm-server-rpc-path', type: 'string', value: '/var/run',
+       description: '''Sets the base path of ESDM's RPC sockets (default: /var/run)
+
+       If this value is changed from the default, the systemd units need to be adapted accordingly
+       by the integrator of ESDM (if systemd is used at all).
+       ''')
+
 ################################################################################
 # Client-related Configuration
 ################################################################################

--- a/service-rpc/service/esdm_rpc_service.h
+++ b/service-rpc/service/esdm_rpc_service.h
@@ -52,9 +52,9 @@ extern "C" {
 
 #else /* ESDM_TESTMODE */
 
-#define ESDM_RPC_UNPRIV_SOCKET "/var/run/esdm-rpc-unpriv.socket"
+#define ESDM_RPC_UNPRIV_SOCKET ESDM_SERVER_RPC_BASE_PATH "/esdm-rpc-unpriv.socket"
 
-#define ESDM_RPC_PRIV_SOCKET "/var/run/esdm-rpc-priv.socket"
+#define ESDM_RPC_PRIV_SOCKET ESDM_SERVER_RPC_BASE_PATH "/esdm-rpc-priv.socket"
 
 #define ESDM_SHM_NAME "/"
 #define ESDM_SHM_STATUS 0x6d647365


### PR DESCRIPTION
By default ESDM places its runtime RPC sockets in /var/run. In some use-cases /var/run is a per-namespace mount, while for example /var/spool is not. With the option to place these sockets in another directory, no bind mounts or other constructs are may needed to use ESDM from these namespaces via its RPC interface.