### PR TITLE
service-rpc: include header for EINTR for client rpc

### DIFF
--- a/service-rpc/client/esdm_rpc_client.h
+++ b/service-rpc/client/esdm_rpc_client.h
@@ -26,6 +26,7 @@
 #include <sys/types.h>
 #include <stdbool.h>
 #include <time.h>
+#include <errno.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
As EINTR is employed by the esdm_invoke macro, I think that errno.h should be included.