### PR TITLE
es_mgr: fix rdrand usage when es_cpu is disabled

### DIFF
--- a/esdm/esdm_es_mgr.c
+++ b/esdm/esdm_es_mgr.c
@@ -697,10 +697,14 @@ int esdm_es_mgr_initialize(void)
 	seed.time = time(NULL);
 
 	for (i = 0; i < ARRAY_SIZE(seed.data); i++) {
+#ifdef ESDM_ES_CPU
 		if (!cpu_es_get(&(seed.data[i]))) {
+#endif
 			clock_gettime(CLOCK_REALTIME, &timeval);
 			seed.data[i] = (unsigned long)timeval.tv_nsec;
+#ifdef ESDM_ES_CPU
 		}
+#endif
 	}
 
 	esdm_pool_insert_aux((uint8_t *)&seed, sizeof(seed), 0);


### PR DESCRIPTION
We got SIGILLs due to rdrand usage on older hardware, even with es_cpu disabled.