### PR TITLE
esdm_es: remove llseek on Linux 6.12+

### DIFF
--- a/addon/linux_esdm_es/esdm_es_mgr.c
+++ b/addon/linux_esdm_es/esdm_es_mgr.c
@@ -116,7 +116,9 @@ static const struct file_operations esdm_cdev_fops = {
 	.open = esdm_cdev_open,
 	.release = esdm_cdev_release,
 	.unlocked_ioctl = esdm_cdev_ioctl,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 	.llseek = no_llseek,
+#endif
 };
 
 static int __init esdm_es_mgr_dev_init(void)


### PR DESCRIPTION
no_llseek was removed in 6.12.

https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=v6.12.16&id=cb787f4ac0c2e439ea8d7e6387b925f74576bdf8