### PR TITLE
Add option to speedup Botan DRNG backend with ChaCha20

### DIFF
--- a/common/meson.build
+++ b/common/meson.build
@@ -64,13 +64,8 @@ else
 	conf_data.set('ESDM_BOTAN', false)
 endif
 
-if get_option('botan_drng_type') == 'chacha20'
-	conf_data.set('ESDM_BOTAN_DRNG_CHACHA20', true)
-	conf_data.set('ESDM_BOTAN_DRNG_HMAC', false)
-else
-	conf_data.set('ESDM_BOTAN_DRNG_CHACHA20', false)
-	conf_data.set('ESDM_BOTAN_DRNG_HMAC', true)
-endif
+conf_data.set('ESDM_BOTAN_DRNG_CHACHA20', get_option('botan_drng_type') == 'chacha20')
+conf_data.set('ESDM_BOTAN_DRNG_HMAC', get_option('botan_drng_type') == 'hmac')
 
 # This option currently is not configurable!
 conf_data.set('CONFIG_ESDM_USE_PTHREAD', true)

--- a/common/meson.build
+++ b/common/meson.build
@@ -64,6 +64,14 @@ else
 	conf_data.set('ESDM_BOTAN', false)
 endif
 
+if get_option('botan_drng_type') == 'chacha20'
+	conf_data.set('ESDM_BOTAN_DRNG_CHACHA20', true)
+	conf_data.set('ESDM_BOTAN_DRNG_HMAC', false)
+else
+	conf_data.set('ESDM_BOTAN_DRNG_CHACHA20', false)
+	conf_data.set('ESDM_BOTAN_DRNG_HMAC', true)
+endif
+
 # This option currently is not configurable!
 conf_data.set('CONFIG_ESDM_USE_PTHREAD', true)
 conf_data.set('THREADING_MAX_THREADS', get_option('threading_max_threads'))

--- a/esdm/esdm_botan.cpp
+++ b/esdm/esdm_botan.cpp
@@ -39,7 +39,8 @@
 #include <botan/hmac_drbg.h>
 #endif
 
-#if (defined(ESDM_BOTAN_DRNG_CHACHA20) && defined(ESDM_BOTAN_DRNG_HMAC)) || (!defined(ESDM_BOTAN_DRNG_CHACHA20) && !defined(ESDM_BOTAN_DRNG_HMAC))
+#if (defined(ESDM_BOTAN_DRNG_CHACHA20) && defined(ESDM_BOTAN_DRNG_HMAC)) ||    \
+	(!defined(ESDM_BOTAN_DRNG_CHACHA20) && !defined(ESDM_BOTAN_DRNG_HMAC))
 #error "Only define one Botan DRNG implementation and/or at least one!"
 #endif
 
@@ -218,14 +219,16 @@ static int esdm_botan_drbg_alloc(void **drng, uint32_t sec_strength)
 	if (!state)
 		return -ENOMEM;
 
-	#ifdef ESDM_BOTAN_DRNG_CHACHA20
+#ifdef ESDM_BOTAN_DRNG_CHACHA20
 	state->drbg.reset(new Botan::ChaCha_RNG());
-	esdm_logger(LOGGER_VERBOSE, LOGGER_C_ANY, "Botan ChaCha20 DRNG core allocated\n");
-	#endif
-	#ifdef ESDM_BOTAN_DRNG_HMAC
+	esdm_logger(LOGGER_VERBOSE, LOGGER_C_ANY,
+		    "Botan ChaCha20 DRNG core allocated\n");
+#endif
+#ifdef ESDM_BOTAN_DRNG_HMAC
 	state->drbg.reset(new Botan::HMAC_DRBG("SHA-512"));
-	esdm_logger(LOGGER_VERBOSE, LOGGER_C_ANY, "Botan SP800-90A HMAC-DRBG core allocated\n");
-	#endif
+	esdm_logger(LOGGER_VERBOSE, LOGGER_C_ANY,
+		    "Botan SP800-90A HMAC-DRBG core allocated\n");
+#endif
 
 	*drng = state;
 	if (state->drbg == nullptr) {

--- a/esdm/esdm_botan.cpp
+++ b/esdm/esdm_botan.cpp
@@ -32,6 +32,7 @@
 
 #include "config.h"
 
+#include <botan/stateful_rng.h>
 #ifdef ESDM_BOTAN_DRNG_CHACHA20
 #include <botan/chacha_rng.h>
 #endif
@@ -171,12 +172,7 @@ const struct esdm_hash_cb esdm_botan_hash_cb = {
 };
 
 struct esdm_botan_drng_state {
-#ifdef ESDM_BOTAN_DRNG_CHACHA20
-	std::unique_ptr<Botan::ChaCha_RNG> drbg;
-#endif
-#ifdef ESDM_BOTAN_DRNG_HMAC
-	std::unique_ptr<Botan::HMAC_DRBG> drbg;
-#endif
+	std::unique_ptr<Botan::Stateful_RNG> drbg;
 };
 
 static int esdm_botan_drbg_seed(void *drng, const uint8_t *inbuf,

--- a/esdm/esdm_botan.cpp
+++ b/esdm/esdm_botan.cpp
@@ -39,6 +39,10 @@
 #include <botan/hmac_drbg.h>
 #endif
 
+#if (defined(ESDM_BOTAN_DRNG_CHACHA20) && defined(ESDM_BOTAN_DRNG_HMAC)) || (!defined(ESDM_BOTAN_DRNG_CHACHA20) && !defined(ESDM_BOTAN_DRNG_HMAC))
+#error "Only define one Botan DRNG implementation and/or at least one!"
+#endif
+
 static const std::string DEFAULT_BOTAN_HASH{ "SHA-3(512)" };
 
 /* introduced, as Botan only exposes unique_ptr for its digests */

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -374,14 +374,12 @@ ESDM for the conditioning operation as well as random number generation. Only
 one backend can be enabled.
 ''')
 
-option('botan_drng_type', type: 'combo', value: 'chacha20',
-       choices: ['chacha20',
-                 'hmac'
-                ],
+option('botan_drng_type', type: 'combo', value: 'hmac',
+       choices: [ 'chacha20', 'hmac' ],
        description: '''Selects the botan DRNG implementation
 
 Botan supports a faster ChaCha20 DRNG and a more conservative HMAC-DRBG implementation,
-which conforms to SP800-90A.
+which conforms to SP800-90A. Default to the conservative option 'hmac'.
 ''')
 
 ################################################################################

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -374,6 +374,16 @@ ESDM for the conditioning operation as well as random number generation. Only
 one backend can be enabled.
 ''')
 
+option('botan_drng_type', type: 'combo', value: 'chacha20',
+       choices: ['chacha20',
+                 'hmac'
+                ],
+       description: '''Selects the botan DRNG implementation
+
+Botan supports a faster ChaCha20 DRNG and a more conservative HMAC-DRBG implementation,
+which conforms to SP800-90A.
+''')
+
 ################################################################################
 # Linux Interface Configuration
 ################################################################################


### PR DESCRIPTION
For small requests ESDMs performance over RPC is mostly dominated by context switch overhead and system calls. Nevertheless a performance increase is possible when optionally allowing the ChaCha20-Ctr-DRNG of Botan, when in this mode.

Before (only HMAC):
```
Request size: 1 | Elapsed: 653.82ms | Rate: 0.03 MB/s | Iterations: 30589.45 1/s
Request size: 2 | Elapsed: 342.09ms | Rate: 0.12 MB/s | Iterations: 58464.88 1/s
Request size: 4 | Elapsed: 317.37ms | Rate: 0.25 MB/s | Iterations: 63018.83 1/s
Request size: 8 | Elapsed: 307.40ms | Rate: 0.52 MB/s | Iterations: 65062.40 1/s
Request size: 16 | Elapsed: 330.37ms | Rate: 0.97 MB/s | Iterations: 60537.75 1/s
Request size: 32 | Elapsed: 318.07ms | Rate: 2.01 MB/s | Iterations: 62878.98 1/s
Request size: 64 | Elapsed: 350.37ms | Rate: 3.65 MB/s | Iterations: 57082.09 1/s
Request size: 128 | Elapsed: 378.39ms | Rate: 6.77 MB/s | Iterations: 52854.83 1/s
Request size: 256 | Elapsed: 443.01ms | Rate: 11.56 MB/s | Iterations: 45146.21 1/s
Request size: 512 | Elapsed: 461.04ms | Rate: 22.21 MB/s | Iterations: 43379.74 1/s
Request size: 1024 | Elapsed: 702.47ms | Rate: 29.15 MB/s | Iterations: 28470.78 1/s
Request size: 2048 | Elapsed: 1.13s | Rate: 36.34 MB/s | Iterations: 17744.18 1/s
```

After (ChaCha20 selected):
```
Request size: 1 | Elapsed: 514.79ms | Rate: 0.04 MB/s | Iterations: 38850.79 1/s
Request size: 2 | Elapsed: 196.20ms | Rate: 0.20 MB/s | Iterations: 101939.18 1/s
Request size: 4 | Elapsed: 188.13ms | Rate: 0.43 MB/s | Iterations: 106309.59 1/s
Request size: 8 | Elapsed: 179.07ms | Rate: 0.89 MB/s | Iterations: 111688.99 1/s
Request size: 16 | Elapsed: 184.59ms | Rate: 1.73 MB/s | Iterations: 108349.60 1/s
Request size: 32 | Elapsed: 182.02ms | Rate: 3.52 MB/s | Iterations: 109876.80 1/s
Request size: 64 | Elapsed: 201.91ms | Rate: 6.34 MB/s | Iterations: 99052.68 1/s
Request size: 128 | Elapsed: 224.12ms | Rate: 11.42 MB/s | Iterations: 89237.39 1/s
Request size: 256 | Elapsed: 291.21ms | Rate: 17.58 MB/s | Iterations: 68678.94 1/s
Request size: 512 | Elapsed: 223.15ms | Rate: 45.89 MB/s | Iterations: 89626.23 1/s
Request size: 1024 | Elapsed: 241.89ms | Rate: 84.67 MB/s | Iterations: 82681.45 1/s
Request size: 2048 | Elapsed: 234.91ms | Rate: 174.37 MB/s | Iterations: 85140.77 1/s
```