### PR TITLE
Reseeding performance fixes with only aux. pool as source

### DIFF
--- a/frontends/botan-rng/botan-rng.cpp
+++ b/frontends/botan-rng/botan-rng.cpp
@@ -86,17 +86,8 @@ void ESDM_RNG::clear()
 
 DSO_PUBLIC
 void ESDM_RNG::fill_bytes_with_input(std::span<uint8_t> out,
-				     std::span<const uint8_t> in)
+				     std::span<const uint8_t>)
 {
-	if (in.size() > 0) {
-		ssize_t ret = 0;
-		// we take additional input, but do not account entropy for it
-		esdm_invoke(esdm_rpcc_write_data(in.data(), in.size()));
-		if (ret != 0) {
-			throw Botan::System_Error(
-				"Writing additional input to ESDM failed");
-		}
-	}
 	if (out.size() > 0) {
 		ssize_t ret = 0;
 		if (m_prediction_resistance)

--- a/frontends/openssl-provider/common.c
+++ b/frontends/openssl-provider/common.c
@@ -104,18 +104,12 @@ static int esdm_rand_uninstantiate(void *ctx __unused)
 static int esdm_rand_generate(void *ctx __unused, unsigned char *out,
 			      size_t outlen, unsigned int strength __unused,
 			      int prediction_resistance,
-			      const unsigned char *addin, size_t addin_len)
+			      const unsigned char *addin __unused, size_t addin_len __unused)
 {
 	ssize_t ret;
 
 	if (!out)
 		goto err;
-
-	if (addin && addin_len > 0) {
-		esdm_invoke(esdm_rpcc_write_data(addin, addin_len));
-		if (ret != 0)
-			goto err;
-	}
 
 	if (prediction_resistance) {
 		esdm_invoke(esdm_rpcc_get_random_bytes_pr(out, outlen));
@@ -133,16 +127,10 @@ err:
 
 static int esdm_rand_reseed(void *ctx __unused,
 			    int prediction_resistance __unused,
-			    const unsigned char *ent, size_t ent_len,
-			    const unsigned char *addin, size_t addin_len)
+			    const unsigned char *ent __unused, size_t ent_len __unused,
+			    const unsigned char *addin __unused, size_t addin_len __unused)
 {
-	ssize_t ret;
-
-	/* unaccounted writing of additional data does no harm */
-	if (ent && ent_len > 0)
-		esdm_invoke(esdm_rpcc_write_data(ent, ent_len));
-	if (addin && addin_len > 0)
-		esdm_invoke(esdm_rpcc_write_data(addin, addin_len));
+	/* Do nothing here, reseeding is done by ESDM itself */
 
 	return 1;
 }
@@ -168,7 +156,7 @@ static size_t esdm_rand_get_seed(void *ctx __unused, unsigned char **buffer,
 				 int entropy_bits, size_t min_len __unused,
 				 size_t max_len __unused,
 				 int prediction_resistance __unused,
-				 const unsigned char *addin, size_t addin_len)
+				 const unsigned char *addin __unused, size_t addin_len __unused)
 {
 #define ENTROPY_BUFFER_SIZE 2048
 	struct esdm_seed_buffer {
@@ -185,12 +173,6 @@ static size_t esdm_rand_get_seed(void *ctx __unused, unsigned char **buffer,
 		goto err;
 	if (ENTROPY_BUFFER_SIZE >= max_len)
 		goto err;
-
-	if (addin && addin_len > 0) {
-		esdm_invoke(esdm_rpcc_write_data(addin, addin_len));
-		if (ret != 0)
-			goto err;
-	}
 
 	seed_buffer = OPENSSL_secure_zalloc(ENTROPY_BUFFER_SIZE);
 	esdm_invoke(esdm_rpcc_get_seed((uint8_t *)seed_buffer,

--- a/frontends/openssl-provider/common.c
+++ b/frontends/openssl-provider/common.c
@@ -104,7 +104,8 @@ static int esdm_rand_uninstantiate(void *ctx __unused)
 static int esdm_rand_generate(void *ctx __unused, unsigned char *out,
 			      size_t outlen, unsigned int strength __unused,
 			      int prediction_resistance,
-			      const unsigned char *addin __unused, size_t addin_len __unused)
+			      const unsigned char *addin __unused,
+			      size_t addin_len __unused)
 {
 	ssize_t ret;
 
@@ -125,10 +126,10 @@ err:
 	return 0;
 }
 
-static int esdm_rand_reseed(void *ctx __unused,
-			    int prediction_resistance __unused,
-			    const unsigned char *ent __unused, size_t ent_len __unused,
-			    const unsigned char *addin __unused, size_t addin_len __unused)
+static int
+esdm_rand_reseed(void *ctx __unused, int prediction_resistance __unused,
+		 const unsigned char *ent __unused, size_t ent_len __unused,
+		 const unsigned char *addin __unused, size_t addin_len __unused)
 {
 	/* Do nothing here, reseeding is done by ESDM itself */
 
@@ -156,7 +157,8 @@ static size_t esdm_rand_get_seed(void *ctx __unused, unsigned char **buffer,
 				 int entropy_bits, size_t min_len __unused,
 				 size_t max_len __unused,
 				 int prediction_resistance __unused,
-				 const unsigned char *addin __unused, size_t addin_len __unused)
+				 const unsigned char *addin __unused,
+				 size_t addin_len __unused)
 {
 #define ENTROPY_BUFFER_SIZE 2048
 	struct esdm_seed_buffer {

--- a/service-rpc/server/esdm_rpc_write_data_s.c
+++ b/service-rpc/server/esdm_rpc_write_data_s.c
@@ -41,12 +41,6 @@ void esdm_rpc_write_data(UnprivAccess_Service *service,
 						    request->data.len, 0);
 		memset_secure(request->data.data, 0, request->data.len);
 
-		/*
-		 * And now force a reseed to ensure the data is properly
-		 * dispersed into the DRNGs.
-		 */
-		esdm_drng_force_reseed();
-
 		closure(&response, closure_data);
 	}
 }


### PR DESCRIPTION
We experienced repeated reseeding of all DRNGs on nearly every request in our setup with only the aux pool configured and a slow smartcard. After some debugging, we saw, that this is rooted in esdm_rpcc_write_data` calling `esdm_drng_force_reseed`. In a first step all writes in the OpenSSL and Botan providers were removed for speed enhancement. Upstream Botan still uses this.

Furthermore, the forced reseed in the RPC server was also removed, as reseeding all DRNGs on every CPUs is not feasible this often with slow entropy sources like smartcards on many core CPUs. Let ESDM consume entropy from the aux pool on its own discretion, may speed up with lower bit or invocation limits.