### PR TITLE
rpc_client: automatically close socket on exec

### DIFF
--- a/service-rpc/client/esdm_rpc_client.c
+++ b/service-rpc/client/esdm_rpc_client.c
@@ -117,7 +117,7 @@ static int esdm_connect_proto_service(esdm_rpc_client_connection_t *rpc_conn)
 	strncpy(addr.sun_path, socketname, sizeof(addr.sun_path));
 #pragma GCC diagnostic pop
 
-	rpc_conn->fd = socket(addr.sun_family, SOCK_SEQPACKET, 0);
+	rpc_conn->fd = socket(addr.sun_family, SOCK_SEQPACKET | SOCK_CLOEXEC, 0);
 	if (rpc_conn->fd < 0) {
 		errsv = errno;
 


### PR DESCRIPTION
We experienced flaky behavior, when a process with an ESDM RPC connection execs/forks another process with opens ESDM RPC connections (sometimes RPC requests never return). This should at least not worsen this situation.