### PR TITLE
 rpc_client: better track and close stale connections

### DIFF
--- a/common/meson.build
+++ b/common/meson.build
@@ -143,4 +143,6 @@ conf_data.set('ESDM_DRNG_MAX_RESEED_BITS', get_option('drng_max_reseed_bits'))
 
 conf_data.set_quoted('ESDM_SERVER_RPC_BASE_PATH', get_option('esdm-server-rpc-path'))
 
+conf_data.set('ESDM_RPC_IDLE_TIMEOUT_USEC', get_option('esdm-server-rpc-idle-timeout-usec'))
+
 configure_file(output: 'config.h', configuration : conf_data)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -293,7 +293,7 @@ getrandom(2) with GRND_RANDOM.
 ''')
 
 # Option for: THREADING_MAX_THREADS
-option('threading_max_threads', type: 'integer', min: 1, value: 64,
+option('threading_max_threads', type: 'integer', min: 1, value: 128,
        description:'''Maximum number of concurrent threads supported.
 
 This value can be set to any arbitrary number. Depending on the number
@@ -500,6 +500,18 @@ the termination signal was received.
 This option is intended when for unknown reasons the accept() does not terminate
 even though the server shall exit.
 ''')
+
+option('esdm-server-rpc-idle-timeout-usec', type: 'integer', value: 2000000,
+       description:'''ESDM-Server: idle connection timeout
+
+Defines the period of time, in which idle/stale RPC sockets are kept in a server
+thread. The client code also uses this value to close idle connections after half
+of this time in order to reduce timeouts.
+
+Lower this value further, when the amount of worker threads shall be not increased
+further and a high rate of short connections may saturates them.
+''')
+
 
 ################################################################################
 # Auxiliary Options

--- a/service-rpc/client/esdm_rpc_client.c
+++ b/service-rpc/client/esdm_rpc_client.c
@@ -20,6 +20,7 @@
 
 #include <errno.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/un.h>
@@ -49,6 +50,17 @@ struct esdm_rpcc_write_buf {
 	esdm_rpc_client_connection_t *rpc_conn;
 };
 
+static void reset_conn_socket(esdm_rpc_client_connection_t *rpc_conn)
+{
+	if (rpc_conn == NULL) {
+		return;
+	}
+	if (rpc_conn->fd >= 0)
+		close(rpc_conn->fd);
+	rpc_conn->fd = -1;
+	memset(&rpc_conn->last_used, 0, sizeof(rpc_conn->last_used));
+}
+
 static void esdm_fini_proto_service(esdm_rpc_client_connection_t *rpc_conn)
 {
 	ProtobufCService *service;
@@ -57,8 +69,7 @@ static void esdm_fini_proto_service(esdm_rpc_client_connection_t *rpc_conn)
 		return;
 
 	if (rpc_conn->fd >= 0) {
-		close(rpc_conn->fd);
-		rpc_conn->fd = -1;
+		reset_conn_socket(rpc_conn);
 	}
 
 	service = &rpc_conn->service;
@@ -88,8 +99,7 @@ static int esdm_connect_proto_service(esdm_rpc_client_connection_t *rpc_conn)
 	int errsv;
 
 	if (rpc_conn->fd >= 0) {
-		close(rpc_conn->fd);
-		rpc_conn->fd = -1;
+		reset_conn_socket(rpc_conn);
 	}
 
 	/* Does the path exist? */
@@ -117,12 +127,16 @@ static int esdm_connect_proto_service(esdm_rpc_client_connection_t *rpc_conn)
 	strncpy(addr.sun_path, socketname, sizeof(addr.sun_path));
 #pragma GCC diagnostic pop
 
-	rpc_conn->fd = socket(addr.sun_family, SOCK_SEQPACKET | SOCK_CLOEXEC, 0);
+	rpc_conn->fd =
+		socket(addr.sun_family, SOCK_SEQPACKET | SOCK_CLOEXEC, 0);
 	if (rpc_conn->fd < 0) {
 		errsv = errno;
 
 		esdm_logger(LOGGER_ERR, LOGGER_C_RPC,
 			    "Error creating socket: %s\n", strerror(errsv));
+
+		reset_conn_socket(rpc_conn);
+
 		return -errsv;
 	}
 
@@ -136,6 +150,9 @@ static int esdm_connect_proto_service(esdm_rpc_client_connection_t *rpc_conn)
 		esdm_logger(LOGGER_ERR, LOGGER_C_RPC,
 			    "Error setting timeout on socket: %s\n",
 			    strerror(errsv));
+
+		reset_conn_socket(rpc_conn);
+
 		return -errsv;
 	}
 
@@ -158,10 +175,14 @@ static int esdm_connect_proto_service(esdm_rpc_client_connection_t *rpc_conn)
 	} while (attempts < (ESDM_CLIENT_RECONNECT_ATTEMPTS) &&
 		 (errsv == EAGAIN || errsv == ECONNREFUSED || errsv == EINTR));
 
-	if (errsv) {
+	if (errsv || attempts >= ESDM_CLIENT_RECONNECT_ATTEMPTS) {
 		esdm_logger(LOGGER_ERR, LOGGER_C_RPC,
 			    "Connection attempt using socket %s failed\n",
 			    socketname);
+		reset_conn_socket(rpc_conn);
+	} else {
+		/* only update this time on a successful connection */
+		clock_gettime(CLOCK_MONOTONIC, &rpc_conn->last_used);
 	}
 
 	return -errsv;
@@ -201,6 +222,8 @@ static int esdm_rpc_client_write_data_fd(esdm_rpc_client_connection_t *rpc_conn,
 				esdm_logger(
 					LOGGER_DEBUG, LOGGER_C_RPC,
 					"Connection to server needs to be re-established\n");
+
+				reset_conn_socket(rpc_conn);
 
 				int rc = esdm_connect_proto_service(rpc_conn);
 				if (rc)
@@ -251,6 +274,7 @@ static int esdm_rpc_client_pack(const ProtobufCMessage *message,
 	struct esdm_rpc_write_data_buf tmp = {
 		.dst_written = 0,
 	};
+	size_t buf_alloc_size;
 
 	tmp.base.append = esdm_rpc_append_data;
 
@@ -261,8 +285,9 @@ static int esdm_rpc_client_pack(const ProtobufCMessage *message,
 		return -EFAULT;
 	}
 
-	data_buf_alloc = malloc(ESDM_RPCC_BUF_WRITE_HEADER_SZ + message_length +
-				sizeof(uint64_t) - 1);
+	buf_alloc_size = ESDM_RPCC_BUF_WRITE_HEADER_SZ + message_length +
+			 sizeof(uint64_t) - 1;
+	data_buf_alloc = malloc(buf_alloc_size);
 	CKNULL(data_buf_alloc, -ENOMEM);
 
 	data_buf = ALIGN_PTR_8(data_buf_alloc, sizeof(uint64_t));
@@ -294,12 +319,16 @@ static int esdm_rpc_client_pack(const ProtobufCMessage *message,
 
 out:
 	/*
-	 * Zeroization not needed, as data will go out through unprotected
-	 * channel anyway. If the data is not already protected, there is a
-	 * bigger problem.
+	 * Zeroization only here is not sufficient.
+	 * Make sure to enable zeroize on alloc and free in your Linux kernel
+	 * and clear data from ESDM in your application or patch
+	 * ESDM to include a cryptographic tunnel to your application.
 	 */
-	if (data_buf_alloc)
+	if (data_buf_alloc) {
+		memset_secure(data_buf_alloc, 0, buf_alloc_size);
 		free(data_buf_alloc);
+		data_buf_alloc = NULL;
+	}
 	return ret;
 }
 
@@ -503,6 +532,7 @@ esdm_rpc_client_read_handler(esdm_rpc_client_connection_t *rpc_conn,
 			msg = ERR_PTR(-EFAULT);
 			closure(msg, closure_data);
 		}
+		clock_gettime(CLOCK_MONOTONIC, &rpc_conn->last_used);
 	} else if (interrupted) {
 		ProtobufCMessage *msg;
 
@@ -534,17 +564,32 @@ static void esdm_client_invoke(ProtobufCService *service,
 	const ProtobufCMethodDescriptor *method = desc->methods + method_index;
 	esdm_rpc_client_connection_t *rpc_conn =
 		(esdm_rpc_client_connection_t *)service;
+	const double half_server_timeout =
+		(double)ESDM_RPC_IDLE_TIMEOUT_USEC / 1E6 / 2.0;
+	struct timespec current_time;
+	double used_before_secs;
 	int ret;
 
 	mutex_w_lock(&rpc_conn->lock);
 
 	do {
+		clock_gettime(CLOCK_MONOTONIC, &current_time);
+		used_before_secs = (double)current_time.tv_sec -
+				   (double)rpc_conn->last_used.tv_sec;
+		used_before_secs += (double)current_time.tv_nsec / 1E9 -
+				    (double)rpc_conn->last_used.tv_nsec / 1E9;
+
 		/*
 		 * Connect to the server if we do not have a connection,
 		 * otherwise reuse the session.
+		 *
+		 * Server keeps the connection open for ESDM_RPC_IDLE_TIMEOUT_USEC, consider it closed a bit earlier.
 		 */
-		if (rpc_conn->fd == -1)
+		if (rpc_conn->fd == -1 ||
+		    used_before_secs >= half_server_timeout) {
+			reset_conn_socket(rpc_conn);
 			CKINT(esdm_connect_proto_service(rpc_conn));
+		}
 
 		/* Pack the protobuf-c data and send it over the wire */
 		CKINT_LOG(esdm_rpc_client_pack(input, method_index, rpc_conn),
@@ -567,8 +612,7 @@ static void esdm_client_destroy(ProtobufCService *service)
 
 	mutex_w_lock(&rpc_conn->lock);
 	if (rpc_conn->fd >= 0) {
-		close(rpc_conn->fd);
-		rpc_conn->fd = -1;
+		reset_conn_socket(rpc_conn);
 	}
 	mutex_w_unlock(&rpc_conn->lock);
 }
@@ -594,6 +638,7 @@ static int esdm_init_proto_service(const ProtobufCServiceDescriptor *descriptor,
 
 	mutex_w_init(&rpc_conn->ref_cnt, 0, 1);
 	rpc_conn->fd = -1;
+	reset_conn_socket(rpc_conn);
 	mutex_w_init(&rpc_conn->lock, 0, 1);
 	atomic_set(&rpc_conn->state, esdm_rpcc_initialized);
 

--- a/service-rpc/client/esdm_rpc_client_internal.h
+++ b/service-rpc/client/esdm_rpc_client_internal.h
@@ -26,6 +26,8 @@
 #include "mutex_w.h"
 #include "queue.h"
 
+#include <time.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -52,6 +54,15 @@ struct esdm_rpc_client_connection {
 	mutex_w_t lock;
 	mutex_w_t ref_cnt;
 	atomic_t state;
+
+	/*
+	 * Used to track successfull reads from esdm-server.
+	 * esdm-server closes idle connections after ESDM_RPC_IDLE_TIMEOUT_USEC.
+	 * Only update this, when data is received or on new connections.
+	 * Otherwise, we may update on writes without answer and keep
+	 * dead connections open for too long.
+	 */
+	struct timespec last_used;
 };
 
 /* Sleep time for poll operations */

--- a/service-rpc/server/esdm_rpc_server.c
+++ b/service-rpc/server/esdm_rpc_server.c
@@ -552,7 +552,8 @@ static int esdm_rpcs_workerloop(struct esdm_rpcs *proto)
 	 * to pay for not using malloc and a thread-local storage
 	 * buffer.
 	 */
-	struct timeval tv = { .tv_sec = 2, .tv_usec = 0 };
+	struct timeval tv = { .tv_sec = ESDM_RPC_IDLE_TIMEOUT_USEC / 1000000,
+			      .tv_usec = ESDM_RPC_IDLE_TIMEOUT_USEC % 1000000 };
 	struct esdm_rpcs_connection *rpc_conn = NULL;
 	struct sockaddr addr;
 	socklen_t addr_len = sizeof(addr);


### PR DESCRIPTION
I've experienced spurious multi second timeouts on client side, which are gone with this change. This fixes correctness issues for us but decreases performance for small requests. I'll try to speed things up again in the future, when time permits.