### PR TITLE
esdm: notify and may trigger reseeds on aux pool insert

### DIFF
--- a/esdm/esdm_es_aux.c
+++ b/esdm/esdm_es_aux.c
@@ -294,6 +294,9 @@ int esdm_pool_insert_aux(const uint8_t *inbuf, size_t inbuflen,
 	 */
 	esdm_shm_status_set_need_entropy();
 
+	/* notify others about newly added entropy */
+	esdm_es_add_entropy();
+
 	return ret;
 }
 


### PR DESCRIPTION
This should improve the achievable DRG.4 rate with the current aux pool setup by a little margin, as it tries to keep DRNGs reseeded faster/when possible after insertion again.