### PR TITLE
esdm_es: fix testing build and uninitialized memory

### DIFF
--- a/addon/linux_esdm_es/Makefile
+++ b/addon/linux_esdm_es/Makefile
@@ -34,21 +34,21 @@ endif
 # are created.
 #
 ifeq ($(BUILD_TESTING), 1)
-CFLAGS_esdm_es_mgr.o	+= -DESDM_TESTING
-CFLAGS_esdm_testing.o	= -DESDM_TESTING
-esdm_es-y		+= esdm_testing.o
-ccflags-y		+= -DCONFIG_ESDM_RAW_HIRES_ENTROPY
-ccflags-y		+= -DCONFIG_ESDM_RAW_JIFFIES_ENTROPY
-ccflags-y		+= -DCONFIG_ESDM_RAW_IRQ_ENTROPY
-ccflags-y		+= -DCONFIG_ESDM_RAW_RETIP_ENTROPY
-ccflags-y		+= -DCONFIG_ESDM_RAW_REGS_ENTROPY
-ccflags-y		+= -DCONFIG_ESDM_RAW_ARRAY
-ccflags-y		+= -DCONFIG_ESDM_IRQ_PERF
-ccflags-y		+= -DCONFIG_ESDM_RAW_SCHED_HIRES_ENTROPY
-ccflags-y		+= -DCONFIG_ESDM_RAW_SCHED_PID_ENTROPY
-ccflags-y		+= -DCONFIG_ESDM_RAW_SCHED_START_TIME_ENTROPY
-ccflags-y		+= -DCONFIG_ESDM_RAW_SCHED_NVCSW_ENTROPY
-ccflags-y		+= -DCONFIG_ESDM_SCHED_PERF
+CFLAGS_esdm_es_mgr.o		+= -DESDM_TESTING
+CFLAGS_esdm_testing.o		= -DESDM_TESTING
+esdm_es-y			+= esdm_testing.o
+ccflags-y			+= -DCONFIG_ESDM_RAW_HIRES_ENTROPY
+ccflags-y			+= -DCONFIG_ESDM_RAW_JIFFIES_ENTROPY
+ccflags-y			+= -DCONFIG_ESDM_RAW_IRQ_ENTROPY
+ccflags-y			+= -DCONFIG_ESDM_RAW_RETIP_ENTROPY
+ccflags-y			+= -DCONFIG_ESDM_RAW_REGS_ENTROPY
+ccflags-y			+= -DCONFIG_ESDM_RAW_ARRAY
+ccflags-y			+= -DCONFIG_ESDM_IRQ_PERF
+ccflags-y			+= -DCONFIG_ESDM_RAW_SCHED_HIRES_ENTROPY
+ccflags-y			+= -DCONFIG_ESDM_RAW_SCHED_PID_ENTROPY
+ccflags-y			+= -DCONFIG_ESDM_RAW_SCHED_START_TIME_ENTROPY
+ccflags-y			+= -DCONFIG_ESDM_RAW_SCHED_NVCSW_ENTROPY
+ccflags-y			+= -DCONFIG_ESDM_SCHED_PERF
 endif
 
 

--- a/addon/linux_esdm_es/Makefile
+++ b/addon/linux_esdm_es/Makefile
@@ -36,9 +36,21 @@ endif
 # When enabling this code base, select the proper interfaces in esdm_testing.h.
 #
 ifeq ($(BUILD_TESTING), 1)
-CFLAGS_esdm_es_mgr.o		+= -DESDM_TESTING
-CFLAGS_esdm_testing.o		= -DESDM_TESTING
-esdm_es-y			+= esdm_testing.o
+CFLAGS_esdm_es_mgr.o	+= -DESDM_TESTING
+CFLAGS_esdm_testing.o	= -DESDM_TESTING
+esdm_es-y		+= esdm_testing.o
+ccflags-y		+= -DCONFIG_ESDM_RAW_HIRES_ENTROPY
+ccflags-y		+= -DCONFIG_ESDM_RAW_JIFFIES_ENTROPY
+ccflags-y		+= -DCONFIG_ESDM_RAW_IRQ_ENTROPY
+ccflags-y		+= -DCONFIG_ESDM_RAW_RETIP_ENTROPY
+ccflags-y		+= -DCONFIG_ESDM_RAW_REGS_ENTROPY
+ccflags-y		+= -DCONFIG_ESDM_RAW_ARRAY
+ccflags-y		+= -DCONFIG_ESDM_IRQ_PERF
+ccflags-y		+= -DCONFIG_ESDM_RAW_SCHED_HIRES_ENTROPY
+ccflags-y		+= -DCONFIG_ESDM_RAW_SCHED_PID_ENTROPY
+ccflags-y		+= -DCONFIG_ESDM_RAW_SCHED_START_TIME_ENTROPY
+ccflags-y		+= -DCONFIG_ESDM_RAW_SCHED_NVCSW_ENTROPY
+ccflags-y		+= -DCONFIG_ESDM_SCHED_PERF
 endif
 
 

--- a/addon/linux_esdm_es/Makefile
+++ b/addon/linux_esdm_es/Makefile
@@ -33,8 +33,6 @@ endif
 # If this interface is enabled, interface files in /sys/kernel/debug/esdm_es
 # are created.
 #
-# When enabling this code base, select the proper interfaces in esdm_testing.h.
-#
 ifeq ($(BUILD_TESTING), 1)
 CFLAGS_esdm_es_mgr.o	+= -DESDM_TESTING
 CFLAGS_esdm_testing.o	= -DESDM_TESTING

--- a/addon/linux_esdm_es/esdm_health.c
+++ b/addon/linux_esdm_es/esdm_health.c
@@ -156,9 +156,9 @@ static struct esdm_health esdm_health = {
 #endif
 #ifdef ESDM_ES_SCHED
 	ESDM_HEALTH_ES_INIT(.es_state[esdm_int_es_sched])
-	.es_state[esdm_int_es_irq].rct.cutoff =
+	.es_state[esdm_int_es_sched].rct.cutoff =
 		ESDM_HEALTH_SCHED_RCT_CUTOFF(CONFIG_ESDM_RCT_CUTOFF),
-	.es_state[esdm_int_es_irq].rct.cutoff_permanent =
+	.es_state[esdm_int_es_sched].rct.cutoff_permanent =
 		ESDM_HEALTH_SCHED_RCT_CUTOFF(CONFIG_ESDM_RCT_CUTOFF_PERMANENT),
 #if (ESDM_HEALTH_OSR(CONFIG_ESDM_SCHED_ENTROPY_RATE) == 1)
 	.es_state[esdm_int_es_sched].apt.cutoff = CONFIG_ESDM_APT_CUTOFF_1,

--- a/addon/linux_esdm_es/esdm_testing.h
+++ b/addon/linux_esdm_es/esdm_testing.h
@@ -219,19 +219,7 @@ config ESDM_SCHED_PERF
 	  the first 1000 entropy events since boot can be sampled.
 */
 
-#define CONFIG_ESDM_RAW_HIRES_ENTROPY
-#define CONFIG_ESDM_RAW_JIFFIES_ENTROPY
-#define CONFIG_ESDM_RAW_IRQ_ENTROPY
-#define CONFIG_ESDM_RAW_RETIP_ENTROPY
-#define CONFIG_ESDM_RAW_REGS_ENTROPY
-#define CONFIG_ESDM_RAW_ARRAY
-#define CONFIG_ESDM_IRQ_PERF
-
-#define CONFIG_ESDM_RAW_SCHED_HIRES_ENTROPY
-#define CONFIG_ESDM_RAW_SCHED_PID_ENTROPY
-#define CONFIG_ESDM_RAW_SCHED_START_TIME_ENTROPY
-#define CONFIG_ESDM_RAW_SCHED_NVCSW_ENTROPY
-#define CONFIG_ESDM_SCHED_PERF
+/* definitions are located in Makefile now! */
 
 /******************************************************************************/
 


### PR DESCRIPTION
- Move testing defines to Makefile in order to fix no testing build.
- Fix initialization/definition of RCT values for scheduler ES by using the correct array index.