### PR TITLE
esdm_es: import and adapt testing helpers

### DIFF
--- a/addon/test/README.md
+++ b/addon/test/README.md
@@ -1,0 +1,3 @@
+These tools are copied and slightly adapted from LRNG.
+
+See: [LRNG](https://github.com/smuellerDD/lrng/tree/master/test/sp80090b)

--- a/addon/test/extractlsb.c
+++ b/addon/test/extractlsb.c
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2019-2025, Stephan Mueller <smueller@chronox.de>
+ *
+ * License: see LICENSE file in root directory
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ALL OF
+ * WHICH ARE HEREBY DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF NOT ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/*
+ * The tool extracts the 4 or 8 LSB of the high-res time stamp and
+ * concatenates them to form a binary data stream.
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <string.h>
+
+#define BITS_PER_SAMPLE 64
+
+/*
+	Extract bits from sample based on significant bit mask
+*/
+
+static unsigned char extract(uint64_t sample, uint64_t mask)
+{
+	unsigned char byte = 0;
+	int i, j = 0;
+
+	for (i = 0; i < BITS_PER_SAMPLE && mask; i++) {
+		if (mask & 1) {
+			byte |= (sample & 1) << j;
+			j++;
+		}
+		mask >>= 1;
+		sample >>= 1;
+	}
+	return (byte);
+}
+
+/*
+	Convert mask in hexadecimal format to binary
+*/
+
+static int hextolong(char *p_strmask, uint64_t *p_mask)
+{
+	uint64_t mask = 0;
+	int count = 0;
+
+	while (*p_strmask) {
+		count++;
+		mask <<= 4;
+
+		if ((*p_strmask >= '0') && (*p_strmask <= '9'))
+			mask |= (uint64_t)(*p_strmask - '0');
+		else if ((*p_strmask >= 'A') && (*p_strmask <= 'F'))
+			mask |= (uint64_t)(*p_strmask - 'A' + 10);
+		else if ((*p_strmask >= '0') && (*p_strmask <= '9'))
+			mask |= (uint64_t)(*p_strmask - 'a' + 10);
+		else
+			return -1;
+
+		p_strmask++;
+	}
+
+	if (count > 16)
+		return (-1);
+
+	*p_mask = mask;
+	return (0);
+}
+
+/*
+	Count the number of bits on
+*/
+
+static int bitcount(uint64_t mask)
+{
+	int i, j = 0;
+
+	for (i = 0; i < BITS_PER_SAMPLE && mask; i++) {
+		if (mask & 1) {
+			j++;
+		}
+		mask >>= 1;
+	}
+	return (j);
+}
+
+/*
+	Print 64 bits of long word masking with '-' those not matching value
+*/
+
+static char *printbits(uint64_t sample, uint64_t value)
+{
+	static char buf[BITS_PER_SAMPLE + 9];
+	char *p_buf = buf + sizeof(buf) - 1;
+	int i;
+	*p_buf-- = '\0';
+	for (i = 0; i < BITS_PER_SAMPLE; i++) {
+		if (i % 8 == 0)
+			*p_buf-- = ' ';
+
+		if ((sample & 1) ^ value)
+			*p_buf = '-';
+		else
+			*p_buf = '0' + (char)value;
+		p_buf--;
+		sample >>= 1;
+	}
+
+	return buf;
+}
+
+int main(int argc, char *argv[])
+{
+	FILE *f = NULL;
+	char buf[64];
+	int fd = -1;
+	uint32_t count;
+	uint32_t i = 0;
+
+	uint64_t mask;
+	uint64_t unchanged0s, unchanged1s;
+	int rc;
+
+	if (argc != 5) {
+		printf("Usage: %s inputfile outfile maxevents mask\n", argv[0]);
+		return 1;
+	}
+
+	f = fopen(argv[1], "r");
+	if (!f) {
+		printf("File %s cannot be opened for read\n", argv[1]);
+		return 1;
+	}
+
+	fd = open(argv[2], O_CREAT | O_WRONLY | O_EXCL, 0777);
+	if (fd < 0) {
+		printf("File %s cannot be opened for write\n", argv[2]);
+		fclose(f);
+		return 1;
+	}
+
+	count = (uint32_t)strtoul(argv[3], NULL, 10);
+	rc = hextolong(argv[4], &mask);
+
+	if (rc) {
+		printf("Mask value is incorrect [%s], use up to 16 hexadecimal characters",
+		       argv[4]);
+		return 1;
+	}
+
+	if (bitcount(mask) > 8) {
+		printf("SP800-90B tool only supports up to 8 bits. Check the mask value");
+		return 1;
+	}
+
+	unchanged0s = 0;
+	unchanged1s = (uint64_t)~0;
+
+	while (fgets(buf, sizeof(buf), f)) {
+		uint64_t sample;
+		ssize_t written;
+		unsigned char val;
+		char *saveptr = NULL;
+		char *res = NULL;
+
+		i++;
+
+		res = strtok_r(buf, " ", &saveptr);
+		if (!res) {
+			printf("strtok_r error\n");
+			return 1;
+		}
+
+		sample = strtoul(res, NULL, 10);
+		unchanged0s |= sample;
+		unchanged1s &= sample;
+
+		val = extract(sample, mask);
+		written = write(fd, &val, sizeof(val));
+		if (written != sizeof(val)) {
+			printf("write error\n");
+			return 1;
+		}
+
+		if (i >= count)
+			break;
+	}
+
+	printf("Processed %d items from %s samples with mask [0x%016llx] significant bits [%d]\n",
+	       i, argv[0], (unsigned long long)mask, bitcount(mask));
+
+	printf("Constant 0s in sample: \n%s\n", printbits(unchanged0s, 0));
+	printf("Constant 1s in sample: \n%s\n", printbits(unchanged1s, 1));
+
+	fclose(f);
+	close(fd);
+	return 0;
+}

--- a/addon/test/getrawentropy.c
+++ b/addon/test/getrawentropy.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2019-2025, Stephan Mueller <smueller@chronox.de>
+ *
+ * License: see LICENSE file in root directory
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ALL OF
+ * WHICH ARE HEREBY DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF NOT ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/*
+ * Compile:
+ * gcc -Wall -pedantic -Wextra -o getrawentropy getrawentropy.c
+ */
+
+#include <errno.h>
+#include <getopt.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#define RAWENTROPY_SAMPLES 1000
+#define DEBUGFS_INTERFACE "/sys/kernel/debug/esdm_es/esdm_raw_sched_hires"
+
+struct opts {
+	size_t samples;
+	char *debugfs_file;
+};
+
+static int getrawentropy(struct opts *opts)
+{
+#define BUFFER_SIZE (RAWENTROPY_SAMPLES * sizeof(uint32_t))
+	uint32_t requested = (uint32_t)opts->samples * sizeof(uint32_t);
+	uint8_t *buffer_p, buffer[BUFFER_SIZE];
+	ssize_t ret;
+	int fd = -1;
+
+	fd = open(opts->debugfs_file, O_RDONLY);
+	if (fd < 0)
+		return errno;
+
+	while (requested) {
+		unsigned int i;
+		unsigned int gather =
+			((BUFFER_SIZE > requested) ? requested : BUFFER_SIZE);
+
+		buffer_p = buffer;
+
+		ret = read(fd, buffer_p, gather);
+		if (ret < 0) {
+			ret = -errno;
+			goto out;
+		}
+
+		for (i = 0; i < (uint32_t)ret / (sizeof(uint32_t)); i++) {
+			uint32_t val;
+
+			memcpy(&val, buffer_p, sizeof(uint32_t));
+			printf("%u\n", val);
+			buffer_p += sizeof(uint32_t);
+		}
+
+		requested -= (uint32_t)ret;
+	}
+
+	ret = 0;
+
+out:
+	if (fd >= 0)
+		close(fd);
+
+	return (int)ret;
+}
+
+int main(int argc, char *argv[])
+{
+	struct opts opts;
+	int c = 0;
+
+	opts.samples = RAWENTROPY_SAMPLES;
+	opts.debugfs_file = DEBUGFS_INTERFACE;
+
+	while (1) {
+		int opt_index = 0;
+		static struct option options[] = {
+			{ "samples", required_argument, 0, 's' },
+			{ "debugfs-file", required_argument, 0, 'f' },
+			{ 0, 0, 0, 0 }
+		};
+		c = getopt_long(argc, argv, "f:s:", options, &opt_index);
+		if (c == -1)
+			break;
+		switch (c) {
+		case 0:
+			switch (opt_index) {
+			case 0:
+				opts.samples = strtoul(optarg, NULL, 10);
+				if (opts.samples == ULONG_MAX)
+					return -EINVAL;
+				break;
+			case 1:
+				opts.debugfs_file = optarg;
+				break;
+			}
+			break;
+
+		case 's':
+			opts.samples = strtoul(optarg, NULL, 10);
+			if (opts.samples == ULONG_MAX)
+				return -EINVAL;
+			break;
+		case 'f':
+			opts.debugfs_file = optarg;
+			break;
+		default:
+			return -EINVAL;
+		}
+	}
+
+	return getrawentropy(&opts);
+}

--- a/addon/test/meson.build
+++ b/addon/test/meson.build
@@ -1,0 +1,11 @@
+extractlsb = executable(
+	'extractlsb',
+	[ 'extractlsb.c' ],
+	install: true
+)
+
+getrawentropy = executable(
+	'getrawentropy',
+	[ 'getrawentropy.c' ],
+	install: true
+)

--- a/meson.build
+++ b/meson.build
@@ -213,6 +213,10 @@ if get_option('esdm-tool').enabled()
 	subdirs += [ 'frontends/tool' ]
 endif
 
+if get_option('validation-helpers').enabled()
+	subdirs += [ 'addon/test' ]
+endif
+
 foreach n : subdirs
 	subdir(n)
 endforeach

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -558,6 +558,8 @@ foot print of the entire code base as much as possible. This goes to the expense
 of the performance.
 ''')
 
+option('validation-helpers', type: 'feature', value: 'disabled',
+       description: 'Enabled build of entropy validation helpers for esdm_es.')
 
 ################################################################################
 # Enable Test configuration


### PR DESCRIPTION
This imports the entropy source testing helpers
from LRNG and adapts them slightly for ESDM.

A full set of scripts is available for LRNG.