### PR TITLE
client: fix non-blocking reads

### DIFF
--- a/common/meson.build
+++ b/common/meson.build
@@ -153,6 +153,10 @@ conf_data.set('ESDM_CLIENT_RX_TX_TIMEOUT_EXPONENT', get_option('client-rx-tx-tim
 conf_data.set('ESDM_CLIENT_RECONNECT_ATTEMPTS', get_option('client-reconnect-attempts'))
 conf_data.set('ESDM_MAX_RX_TX_RETRIES', 5)
 
+# chunk pr requests, such that slow entropy sources return fast in server
+# and don't block the server longer than client read timeouts on average
+conf_data.set('ESDM_RPC_MAX_PR_REQUEST_SIZE', 32)
+
 conf_data.set('ESDM_TESTMODE', get_option('testmode').enabled())
 
 if build_machine.system() == 'linux'

--- a/service-rpc/client/esdm_rpc_client.c
+++ b/service-rpc/client/esdm_rpc_client.c
@@ -535,9 +535,11 @@ static void esdm_client_invoke(ProtobufCService *service,
 			  "Sending of data failed: %d\n", ret);
 
 		/* Receive data */
-		CKINT_LOG(esdm_rpc_client_read_handler(rpc_conn, method->output,
-						       closure, closure_data),
-			  "Receiving of data failed: %d\n", ret);
+		ret = esdm_rpc_client_read_handler(rpc_conn, method->output, closure, closure_data);
+		/* EAGAIN is ok here, since sockets are non-blocking now */
+		if (ret < 0 && ret != -EAGAIN) {
+			esdm_logger(LOGGER_ERR, LOGGER_C_ANY, "Receiving of data failed: %d\n", ret);
+		}
 	} while (ret == -EAGAIN);
 
 out:

--- a/service-rpc/client/esdm_rpc_get_random_bytes_pr_c.c
+++ b/service-rpc/client/esdm_rpc_get_random_bytes_pr_c.c
@@ -78,7 +78,7 @@ ssize_t esdm_rpcc_get_random_bytes_pr_int(uint8_t *buf, size_t buflen,
 		buffer.buf = buf;
 		buffer.buflen = buflen;
 
-		msg.len = min_size(maxbuflen, buflen);
+		msg.len = min_size(ESDM_RPC_MAX_PR_REQUEST_SIZE, buflen);
 
 		unpriv_access__rpc_get_random_bytes_pr(
 			&rpc_conn->service, &msg,

--- a/service-rpc/server/esdm_rpc_get_random_bytes_pr_s.c
+++ b/service-rpc/server/esdm_rpc_get_random_bytes_pr_s.c
@@ -39,8 +39,8 @@ void esdm_rpc_get_random_bytes_pr(UnprivAccess_Service *service,
 	uint8_t rndval[ESDM_RPC_MAX_DATA];
 	(void)service;
 
-	if (request == NULL || request->len > sizeof(rndval)) {
-		response.ret = -(int32_t)sizeof(rndval);
+	if (request == NULL || request->len > ESDM_RPC_MAX_PR_REQUEST_SIZE) {
+		response.ret = -ESDM_RPC_MAX_PR_REQUEST_SIZE;
 		closure(&response, closure_data);
 	} else {
 		response.ret = (int)esdm_get_random_bytes_pr_noblock(


### PR DESCRIPTION
Hi Stephan,

I'm sorry, that this slipped through. It only showed up on slow systems by default.
A small bugfix release is probably needed, as this breaks the current semantics of esdm_get_random_bytes_{pr,full} by returning too early.

BR
Markus