### PR TITLE
Allow full entropy output of PR DRNG & remove RDRAND fallback for RDSEED

### DIFF
--- a/esdm/es_cpu/cpu_random_x86.h
+++ b/esdm/es_cpu/cpu_random_x86.h
@@ -54,7 +54,12 @@
 
 static inline int rdseed_available(void)
 {
+	static int rdseed_avail = -1;
 	unsigned int eax, ebx, ecx, edx;
+
+	if (rdseed_avail > -1) {
+		return rdseed_avail;
+	}
 
 	/* Read the maximum leaf */
 	cpuid_eax(0, eax, ebx, ecx, edx);
@@ -64,14 +69,26 @@ static inline int rdseed_available(void)
 		/* read advanced features eax = 7, ecx = 0 */
 		cpuid_eax_ecx(7, 0, eax, ebx, ecx, edx);
 
-		return !!(ebx & EXT_FEAT_EBX_RDSEED);
+		rdseed_avail = !!(ebx & EXT_FEAT_EBX_RDSEED);
+	} else {
+		rdseed_avail = false;
 	}
-	return false;
+
+	esdm_logger(LOGGER_DEBUG, LOGGER_C_ANY,
+			"RDSEED support %sdetected\n",
+			rdseed_avail ? "" : "not ");
+
+	return rdseed_avail;
 }
 
 static inline int rdrand_available(void)
 {
+	static int rdrand_avail = -1;
 	unsigned int eax, ebx, ecx, edx;
+
+	if (rdrand_avail > -1) {
+		return rdrand_avail;
+	}
 
 	/* Read the maximum leaf */
 	cpuid_eax(0, eax, ebx, ecx, edx);
@@ -79,25 +96,24 @@ static inline int rdrand_available(void)
 	/* Only make call if the leaf is present */
 	if (eax >= 1) {
 		cpuid_eax(1, eax, ebx, ecx, edx);
-		return !!(ecx & ECX_RDRAND);
+		rdrand_avail = !!(ecx & ECX_RDRAND);
+	} else {
+		rdrand_avail = false;
 	}
 
-	return false;
+	esdm_logger(LOGGER_DEBUG, LOGGER_C_ANY,
+			"RDRAND support %sdetected\n",
+			rdrand_avail ? "" : "not ");
+
+	return rdrand_avail;
 }
 
 static inline bool cpu_es_x86_rdseed(unsigned long *buf)
 {
 	unsigned int retry = 0;
 	unsigned char ok;
-	static int rdseed_avail = -1;
 
-	if (rdseed_avail == -1) {
-		rdseed_avail = rdseed_available();
-		esdm_logger(LOGGER_DEBUG, LOGGER_C_ANY,
-			    "RDSEED support %sdetected\n",
-			    rdseed_avail ? "" : "not ");
-	}
-	if (!rdseed_avail)
+	if (!rdseed_available())
 		return false;
 
 	do {
@@ -112,15 +128,8 @@ static inline bool cpu_es_x86_rdseed(unsigned long *buf)
 static inline bool cpu_es_x86_rdrand(unsigned long *buf)
 {
 	int ok;
-	static int rdrand_avail = -1;
 
-	if (rdrand_avail == -1) {
-		rdrand_avail = rdrand_available();
-		esdm_logger(LOGGER_DEBUG, LOGGER_C_ANY,
-			    "RDRAND support %sdetected\n",
-			    rdrand_avail ? "" : "not ");
-	}
-	if (!rdrand_avail)
+	if (!rdrand_available())
 		return false;
 
 	__asm__ __volatile__("1: " RDRAND_LONG "\n\t"
@@ -135,11 +144,18 @@ static inline bool cpu_es_x86_rdrand(unsigned long *buf)
 
 static inline bool cpu_es_get(unsigned long *buf)
 {
-	bool ret = cpu_es_x86_rdseed(buf);
-
-	if (!ret)
+	/*
+	 * perform no fallback between both options,
+	 * as compression would be missing for rdrand,
+	 * when rdseed was initially detected
+	 */
+	if (rdseed_available()) {
+		return cpu_es_x86_rdseed(buf);
+	}
+	if (rdrand_available()) {
 		return cpu_es_x86_rdrand(buf);
-	return ret;
+	}
+	return false;
 }
 
 static inline unsigned int cpu_es_multiplier(void)

--- a/esdm/esdm_drng_mgr.c
+++ b/esdm/esdm_drng_mgr.c
@@ -457,8 +457,14 @@ static uint32_t esdm_drng_seed_es_nolock(struct esdm_drng *drng,
 				drng_type);
 		}
 
+		/*
+		 * The PR DRNG should be a RBG3(RS) if properly seeded, therefore
+		 * oversample ES by 64 bit, when seeding this DRNG instance.
+		 * See SP800-90C sec. 6.5.1.2.
+		 */
 		esdm_fill_seed_buffer(&seedbuf,
-				      esdm_get_seed_entropy_osr(do_full_init),
+				      esdm_get_seed_entropy_osr(do_full_init,
+				      !do_full_init && drng == &esdm_drng_pr),
 				      forced && do_full_init);
 
 		collected_entropy += esdm_entropy_rate_eb(&seedbuf);
@@ -1054,7 +1060,7 @@ ssize_t esdm_get_seed(uint64_t *buf, size_t nbytes,
 		esdm_fill_seed_buffer(
 			eb,
 			esdm_get_seed_entropy_osr(
-				!(flags & ESDM_GET_SEED_FULLY_SEEDED)),
+				!(flags & ESDM_GET_SEED_FULLY_SEEDED), false),
 			false);
 		collected_bits = esdm_entropy_rate_eb(eb);
 

--- a/esdm/esdm_es_aux.h
+++ b/esdm/esdm_es_aux.h
@@ -24,6 +24,8 @@
 #include "esdm_drng_mgr.h"
 #include "esdm_es_mgr_cb.h"
 
+#include <assert.h>
+
 extern struct esdm_es_cb esdm_es_aux;
 
 /****************************** Helper code ***********************************/
@@ -42,13 +44,21 @@ static inline uint32_t esdm_security_strength(void)
 	return min_uint32(ESDM_FULL_SEED_ENTROPY_BITS, esdm_get_digestsize());
 }
 
-static inline uint32_t esdm_get_seed_entropy_osr(bool do_full_init)
+static inline uint32_t esdm_get_seed_entropy_osr(bool do_full_init, bool full_entropy)
 {
 	uint32_t requested_bits = esdm_security_strength();
+
+	assert((!do_full_init && !full_entropy) || (do_full_init != full_entropy));
 
 	/* Apply oversampling during initialization according to SP800-90C */
 	if (esdm_sp80090c_compliant() && do_full_init)
 		requested_bits += ESDM_SEED_BUFFER_INIT_ADD_BITS;
+	/*
+	 * Apply oversampling when aiming for RBG3(RS) mode,
+	 * see SP800-90C sec. 6.5.1.2
+	 */
+	if (esdm_sp80090c_compliant() && full_entropy)
+		requested_bits += ESDM_OVERSAMPLE_ES_BITS;
 	return requested_bits;
 }
 

--- a/esdm/esdm_es_jent.c
+++ b/esdm/esdm_es_jent.c
@@ -158,7 +158,7 @@ err:
 
 static int esdm_jent_async_monitor(void)
 {
-	unsigned int i, requested_bits = esdm_get_seed_entropy_osr(false);
+	unsigned int i, requested_bits = esdm_get_seed_entropy_osr(false, false);
 
 	if (!esdm_config_es_jent_async_enabled())
 		return 0;
@@ -255,7 +255,7 @@ static void esdm_jent_get_check(struct entropy_es *eb_es,
 {
 	/* serve small requests without initial oversampling from async cache */
 	if (esdm_config_es_jent_async_enabled() &&
-	    (requested_bits == esdm_get_seed_entropy_osr(false))) {
+	    (requested_bits == esdm_get_seed_entropy_osr(false, false))) {
 		esdm_jent_async_get(eb_es, requested_bits, unused);
 	} else {
 		mutex_w_lock(&esdm_jent_lock);

--- a/esdm/esdm_es_mgr.c
+++ b/esdm/esdm_es_mgr.c
@@ -447,7 +447,7 @@ bool esdm_fully_seeded(bool do_full_init, uint32_t collected_entropy,
 		return (result >= 2);
 	}
 
-	return (collected_entropy >= esdm_get_seed_entropy_osr(do_full_init));
+	return (collected_entropy >= esdm_get_seed_entropy_osr(do_full_init, false));
 }
 
 uint32_t esdm_entropy_rate_eb(struct entropy_buf *eb)
@@ -554,7 +554,7 @@ static uint32_t esdm_init_entropy_level(bool fully_seeded)
 		       /* Approximation so that two ES should deliver 240 bits each */
 		       (2 * ESDM_AIS2031_NPTRNG_MIN_ENTROPY) :
 		       /* Apply SP800-90C oversampling if applicable */
-		       esdm_get_seed_entropy_osr(!fully_seeded);
+		       esdm_get_seed_entropy_osr(!fully_seeded, false);
 }
 
 /**
@@ -784,7 +784,7 @@ void esdm_fill_seed_buffer(struct entropy_buf *eb, uint32_t requested_bits,
 	(void)ret;
 
 	/*
-	 * Require at least 128 bits of entropy for any reseed. If the ESDM is
+	 * Require at least 256 bits of entropy for any reseed. If the ESDM is
 	 * operated SP800-90C compliant we want to comply with SP800-90A section
 	 * 9.2 mandating that DRNG is reseeded with the security strength.
 	 */


### PR DESCRIPTION
Hi Stephan,

the full entropy output option for the PR DRNG is also handy, for e.g. converting a PTG.3 (2011) to a PTG.3 (2024).

The CPU fix is only for correctness. I currently don't use an entropy estimate > 0 for this kind of source in my setups.

BR
Markus