### PR TITLE
es_mgr: enable parallel seed construction

### DIFF
--- a/common/meson.build
+++ b/common/meson.build
@@ -85,6 +85,8 @@ conf_data.set('ESDM_BOTAN_DRNG_HMAC', get_option('botan_drng_type') == 'hmac')
 conf_data.set('THREADING_MAX_WORKER_THREADS', get_option('threading_max_worker_threads'))
 conf_data.set('THREADING_MAX_THREADS', get_option('threading_max_worker_threads') + 3)
 
+conf_data.set('ESDM_ES_PARALLEL_FETCH', get_option('es_parallel_fetch').enabled())
+
 conf_data.set('ESDM_ES_JENT', get_option('es_jent').enabled())
 conf_data.set('ESDM_JENT_ENTROPY_RATE',
 	      get_option('es_jent_entropy_rate'))

--- a/common/threading_support.c
+++ b/common/threading_support.c
@@ -31,6 +31,7 @@
 #include "bool.h"
 #include "config.h"
 #include "esdm_logger.h"
+#include "helper.h"
 #include "memset_secure.h"
 #include "mutex_w.h"
 #include "ret_checkers.h"
@@ -618,6 +619,36 @@ int thread_start(int (*start_routine)(void *), void *tdata,
 void thread_stop_spawning(void)
 {
 	atomic_bool_set_true(&threads_in_cancel);
+}
+
+void thread_fork_join(void *(*start_routine)(void *), void *args,
+		      size_t arg_stride, size_t num)
+{
+	if (num == 0)
+		return;
+
+	bool have_parallelism = num > 1 && esdm_online_nodes() > 1;
+	pthread_t tids[num];
+	bool spawned[num];
+	char *arg_base = args;
+	size_t i;
+
+	for (i = 0; i < num; i++) {
+		void *arg = arg_base + i * arg_stride;
+
+		if (have_parallelism &&
+		    pthread_create(&tids[i], NULL, start_routine, arg) == 0) {
+			spawned[i] = true;
+		} else {
+			spawned[i] = false;
+			start_routine(arg);
+		}
+	}
+
+	for (i = 0; i < num; i++) {
+		if (spawned[i])
+			pthread_join(tids[i], NULL);
+	}
 }
 
 DSO_PUBLIC

--- a/common/threading_support.c
+++ b/common/threading_support.c
@@ -627,7 +627,13 @@ void thread_fork_join(void *(*start_routine)(void *), void *args,
 	if (num == 0)
 		return;
 
-	bool have_parallelism = num > 1 && esdm_online_nodes() > 1;
+	/*
+	 * Run inline during teardown: threads spawned here are invisible to
+	 * thread_cancel, so a forced cancellation of the caller would orphan
+	 * them while they still write into the caller's stack frame.
+	 */
+	bool have_parallelism = num > 1 && esdm_online_nodes() > 1 &&
+				!atomic_bool_read(&threads_in_cancel);
 	pthread_t tids[num];
 	bool spawned[num];
 	char *arg_base = args;

--- a/common/threading_support.h
+++ b/common/threading_support.h
@@ -22,6 +22,7 @@
 #define THREADING_SUPPORT_H
 
 #include <pthread.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #include "bool.h"
@@ -133,6 +134,38 @@ int thread_wait_all(bool system_threads);
  */
 int thread_start(int (*start_routine)(void *), void *tdata,
 		 uint32_t thread_group, int *ret_ancestor);
+
+/**
+ * @brief - Run @num independent tasks concurrently and wait for all of them.
+ *
+ * Each task is invoked as @start_routine(arg_i), where arg_i is the i-th
+ * element of a contiguous array at @args with element size @arg_stride.
+ *
+ * Unlike thread_start, this helper spawns plain pthreads directly instead
+ * of going through the shared thread pool. The join is therefore bounded
+ * to exactly the threads spawned in this batch, avoiding the deadlocks
+ * that thread_wait can hit when unrelated worker threads were scheduled
+ * from the caller in the meantime.
+ *
+ * If pthread_create fails for an individual task, that task is executed
+ * inline on the calling thread as a fallback. When fewer than two CPUs
+ * are online or @num <= 1, all tasks run inline.
+ *
+ * Intended for short-lived batches of independent work where deadlock-free
+ * joining matters more than thread reuse (e.g. fetching seed material from
+ * multiple entropy sources during a reseed).
+ *
+ * @param [in] start_routine Function invoked once per task. Its return
+ *			     value is discarded; report results via the
+ *			     task's argument record.
+ * @param [in] args Pointer to a contiguous array of per-task argument
+ *		    records.
+ * @param [in] arg_stride Size of one record in bytes (e.g.
+ *			  sizeof(args[0])).
+ * @param [in] num Number of tasks to run; zero is a no-op.
+ */
+void thread_fork_join(void *(*start_routine)(void *), void *args,
+		      size_t arg_stride, size_t num);
 
 #define ESDM_THREAD_MAX_NAMELEN 16
 /**

--- a/esdm/esdm_es_mgr.c
+++ b/esdm/esdm_es_mgr.c
@@ -161,6 +161,24 @@ static int esdm_es_monitor_thread(void *data)
 	return arg->rc;
 }
 
+#ifdef ESDM_ES_PARALLEL_FETCH
+struct esdm_es_get_ent_thread_arg {
+	unsigned int es_idx;
+	struct entropy_es *eb_es;
+	uint32_t requested_bits;
+	bool fully_seeded;
+};
+
+static void *esdm_es_get_ent_thread(void *data)
+{
+	struct esdm_es_get_ent_thread_arg *arg = data;
+
+	esdm_es[arg->es_idx]->get_ent(arg->eb_es, arg->requested_bits,
+				      arg->fully_seeded);
+	return NULL;
+}
+#endif
+
 /* ES monitor worker loop */
 int esdm_es_mgr_monitor_initialize(void (*priv_init_completion)(void))
 {
@@ -824,9 +842,16 @@ void esdm_fill_seed_buffer(struct entropy_buf *eb, uint32_t requested_bits,
 			   bool force)
 {
 	struct esdm_state *state = &esdm_state;
+#ifdef ESDM_ES_PARALLEL_FETCH
+	struct esdm_es_get_ent_thread_arg args[esdm_ext_es_last];
+	pthread_t tids[esdm_ext_es_last];
+	bool spawned[esdm_ext_es_last];
+	bool have_parallelism = esdm_online_nodes() > 1;
+#endif
 	uint32_t i, req_ent = esdm_sp80090c_compliant() ?
 				      esdm_security_strength() :
 				      ESDM_FULL_SEED_ENTROPY_BITS;
+	bool fully_seeded = atomic_bool_read(&state->esdm_fully_seeded);
 	int ret;
 
 	/* Guarantee that requested bits is a multiple of bytes */
@@ -842,20 +867,60 @@ void esdm_fill_seed_buffer(struct entropy_buf *eb, uint32_t requested_bits,
 	 * operated SP800-90C compliant we want to comply with SP800-90A section
 	 * 9.2 mandating that DRNG is reseeded with the security strength.
 	 */
-	if (!force && atomic_bool_read(&state->esdm_fully_seeded) &&
-	    (esdm_avail_entropy() < req_ent)) {
+	if (!force && fully_seeded && (esdm_avail_entropy() < req_ent)) {
 		for_each_esdm_es (i)
 			eb->entropy_es[i].e_bits = 0;
 
 		goto wakeup;
 	}
 
+#ifdef ESDM_ES_PARALLEL_FETCH
+	/*
+	 * Feed seed material from all entropy sources in parallel and wait
+	 * for completion. We use plain pthread_create/pthread_join here
+	 * instead of the shared thread pool so the join is bounded to the
+	 * exact threads spawned in this batch. If thread creation fails for
+	 * any source, run that source inline as a fallback.
+	 *
+	 * Using the thread pool would lead to deadlocks on join, as we cannot
+	 * guarantee, that no other threads were already spawned from the one
+	 * requesting that wait/join. If this should be needed in more than one
+	 * place add a fork + join abstraction in threading_support.{c,h}.
+	 */
+	for_each_esdm_es (i) {
+		args[i].es_idx = i;
+		args[i].eb_es = &eb->entropy_es[i];
+		args[i].requested_bits = requested_bits;
+		args[i].fully_seeded = fully_seeded;
+
+		/*
+		 * Only use parallel fetches if more than one processor core
+		 * is available for this task.
+		 */
+		if (have_parallelism &&
+		    pthread_create(&tids[i], NULL,
+				   esdm_es_get_ent_thread,
+				   &args[i]) == 0) {
+			spawned[i] = true;
+		} else {
+			spawned[i] = false;
+			esdm_es[i]->get_ent(&eb->entropy_es[i], requested_bits,
+					    fully_seeded);
+		}
+	}
+
+	for_each_esdm_es (i) {
+		if (spawned[i]) {
+			pthread_join(tids[i], NULL);
+		}
+	}
+#else
 	/* Concatenate the output of the entropy sources. */
 	for_each_esdm_es (i) {
-		esdm_es[i]->get_ent(
-			&eb->entropy_es[i], requested_bits,
-			atomic_bool_read(&state->esdm_fully_seeded));
+		esdm_es[i]->get_ent(&eb->entropy_es[i], requested_bits,
+				    fully_seeded);
 	}
+#endif
 
 wakeup:
 	esdm_writer_wakeup();

--- a/esdm/esdm_es_mgr.c
+++ b/esdm/esdm_es_mgr.c
@@ -844,9 +844,6 @@ void esdm_fill_seed_buffer(struct entropy_buf *eb, uint32_t requested_bits,
 	struct esdm_state *state = &esdm_state;
 #ifdef ESDM_ES_PARALLEL_FETCH
 	struct esdm_es_get_ent_thread_arg args[esdm_ext_es_last];
-	pthread_t tids[esdm_ext_es_last];
-	bool spawned[esdm_ext_es_last];
-	bool have_parallelism = esdm_online_nodes() > 1;
 #endif
 	uint32_t i, req_ent = esdm_sp80090c_compliant() ?
 				      esdm_security_strength() :
@@ -875,45 +872,14 @@ void esdm_fill_seed_buffer(struct entropy_buf *eb, uint32_t requested_bits,
 	}
 
 #ifdef ESDM_ES_PARALLEL_FETCH
-	/*
-	 * Feed seed material from all entropy sources in parallel and wait
-	 * for completion. We use plain pthread_create/pthread_join here
-	 * instead of the shared thread pool so the join is bounded to the
-	 * exact threads spawned in this batch. If thread creation fails for
-	 * any source, run that source inline as a fallback.
-	 *
-	 * Using the thread pool would lead to deadlocks on join, as we cannot
-	 * guarantee, that no other threads were already spawned from the one
-	 * requesting that wait/join. If this should be needed in more than one
-	 * place add a fork + join abstraction in threading_support.{c,h}.
-	 */
 	for_each_esdm_es (i) {
 		args[i].es_idx = i;
 		args[i].eb_es = &eb->entropy_es[i];
 		args[i].requested_bits = requested_bits;
 		args[i].fully_seeded = fully_seeded;
-
-		/*
-		 * Only use parallel fetches if more than one processor core
-		 * is available for this task.
-		 */
-		if (have_parallelism &&
-		    pthread_create(&tids[i], NULL,
-				   esdm_es_get_ent_thread,
-				   &args[i]) == 0) {
-			spawned[i] = true;
-		} else {
-			spawned[i] = false;
-			esdm_es[i]->get_ent(&eb->entropy_es[i], requested_bits,
-					    fully_seeded);
-		}
 	}
-
-	for_each_esdm_es (i) {
-		if (spawned[i]) {
-			pthread_join(tids[i], NULL);
-		}
-	}
+	thread_fork_join(esdm_es_get_ent_thread, args, sizeof(args[0]),
+			 esdm_ext_es_last);
 #else
 	/* Concatenate the output of the entropy sources. */
 	for_each_esdm_es (i) {

--- a/flake.nix
+++ b/flake.nix
@@ -233,8 +233,6 @@
                   ]
                   ++ [
                     "-Des_jent_osr=4"
-                    "-Des_pkcs11=enabled"
-                    "-Des_pkcs11_module_path=/home/mtheil/Code/mini-pkcs11-rand/result/lib/libp11rand.so"
                   ];
                 mesonBuildType = if debugEsdm then "debug" else "release";
                 doCheck = false;

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -556,6 +556,23 @@ shall be adjusted.
 The value must not be lower than 1.
 ''')
 
+# Option for: ESDM_ES_PARALLEL_FETCH
+option('es_parallel_fetch', type: 'feature', value: 'enabled',
+       description: '''Fetch seed material from entropy sources in parallel.
+
+When enabled, the entropy source manager spawns one thread per entropy
+source to gather seed material concurrently during a reseed, joining them
+afterwards. This reduces reseed latency when slow entropy sources (e.g.
+TPM 2.0 or PKCS#11 tokens) are configured.
+
+Parallel fetching is only used at runtime if more than one processor core
+is available; otherwise the sources are queried sequentially. If thread
+creation fails for an individual source, that source is queried inline as
+a fallback.
+
+When disabled, the entropy sources are always queried sequentially.
+''')
+
 option('drng_reseed_threshold_bits', type: 'integer', value: 0xffffffff,
        description: '''Besides request count based reseeding, this option can
        be used to enable request size (Bit) based reseeding. Set this to


### PR DESCRIPTION
This is added to speed up seed construction in presence of slow sources when no entropy buffering is allowed.